### PR TITLE
Add IAM authentication support for ElastiCache Valkey

### DIFF
--- a/examples/AWSDriverExample/src/main/java/software/amazon/DatabaseConnectionWithCacheExample.java
+++ b/examples/AWSDriverExample/src/main/java/software/amazon/DatabaseConnectionWithCacheExample.java
@@ -12,6 +12,13 @@ public class DatabaseConnectionWithCacheExample {
   private static final String DB_CONNECTION_STRING = env.get("DB_CONNECTION_STRING");
   private static final String CACHE_RW_SERVER_ADDR = env.get("CACHE_RW_SERVER_ADDR");
   private static final String CACHE_RO_SERVER_ADDR = env.get("CACHE_RO_SERVER_ADDR");
+  // If the cache server is authenticated with IAM
+  private static final String CACHE_NAME = env.get("CACHE_NAME");
+  // Both IAM and traditional auth uses the same CACHE_USERNAME
+  private static final String CACHE_USERNAME = env.get("CACHE_USERNAME"); // e.g., "iam-user-01" / "username"
+  private static final String CACHE_IAM_REGION = env.get("CACHE_IAM_REGION"); // e.g., "us-west-2"
+  // If the cache server is authenticated with traditional username password
+  // private static final String CACHE_PASSWORD = env.get("CACHE_PASSWORD");
   private static final String USERNAME = env.get("DB_USERNAME");
   private static final String PASSWORD = env.get("DB_PASSWORD");
   private static final String USE_SSL = env.get("USE_SSL");
@@ -30,6 +37,12 @@ public class DatabaseConnectionWithCacheExample {
     properties.setProperty("wrapperPlugins", "dataRemoteCache");
     properties.setProperty("cacheEndpointAddrRw", CACHE_RW_SERVER_ADDR);
     properties.setProperty("cacheEndpointAddrRo", CACHE_RO_SERVER_ADDR);
+    // If the cache server is authenticated with IAM
+    properties.setProperty("cacheName", CACHE_NAME);
+    properties.setProperty("cacheUsername", CACHE_USERNAME);
+    properties.setProperty("cacheIamRegion", CACHE_IAM_REGION);
+    // If the cache server is authenticated with traditional username password
+    // properties.setProperty("cachePassword", PASSWORD);
     properties.setProperty("cacheUseSSL", USE_SSL); // "true" or "false"
     properties.setProperty("wrapperLogUnclosedConnections", "true");
     String queryStr = "/*+ CACHE_PARAM(ttl=300s) */ select * from cinemas";

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CacheConnection.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CacheConnection.java
@@ -1,27 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package software.amazon.jdbc.plugin.cache;
 
 import io.lettuce.core.RedisClient;
-import io.lettuce.core.RedisCommandExecutionException;
+import io.lettuce.core.RedisCredentials;
+import io.lettuce.core.RedisCredentialsProvider;
 import io.lettuce.core.RedisURI;
+import io.lettuce.core.RedisCommandExecutionException;
 import io.lettuce.core.SetArgs;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.codec.ByteArrayCodec;
 import io.lettuce.core.resource.ClientResources;
-import software.amazon.jdbc.AwsWrapperProperty;
+import reactor.core.publisher.Mono;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 import java.util.logging.Logger;
 import org.apache.commons.pool2.BasePooledObjectFactory;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.commons.pool2.PooledObject;
+import software.amazon.jdbc.AwsWrapperProperty;
 import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.authentication.AwsCredentialsManager;
+import software.amazon.jdbc.plugin.iam.ElastiCacheIamTokenUtility;
 import software.amazon.jdbc.util.StringUtils;
 
 // Abstraction layer on top of a connection to a remote cache server
@@ -31,17 +56,20 @@ public class CacheConnection {
   private static volatile GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> readConnectionPool;
   private static volatile GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> writeConnectionPool;
   private static final GenericObjectPoolConfig<StatefulRedisConnection<byte[], byte[]>> poolConfig = createPoolConfig();
-  private final String cacheRwServerAddr; // read-write cache server
-  private final String cacheRoServerAddr; // read-only cache server
-  private MessageDigest msgHashDigest = null;
 
   private static final int DEFAULT_POOL_SIZE  = 20;
   private static final int DEFAULT_POOL_MAX_IDLE = 20;
   private static final int DEFAULT_POOL_MIN_IDLE = 0;
   private static final long DEFAULT_MAX_BORROW_WAIT_MS = 100;
+  private static final long TOKEN_CACHE_DURATION = 15 * 60 - 30;
 
   private static final ReentrantLock READ_LOCK = new ReentrantLock();
   private static final ReentrantLock WRITE_LOCK = new ReentrantLock();
+
+  private final String cacheRwServerAddr; // read-write cache server
+  private final String cacheRoServerAddr; // read-only cache server
+  private final String[] defaultCacheServerHostAndPort;
+  private MessageDigest msgHashDigest = null;
 
   protected static final AwsWrapperProperty CACHE_RW_ENDPOINT_ADDR =
       new AwsWrapperProperty(
@@ -61,7 +89,38 @@ public class CacheConnection {
           "true",
           "Whether to use SSL for cache connections.");
 
+  protected static final AwsWrapperProperty CACHE_IAM_REGION =
+      new AwsWrapperProperty(
+          "cacheIamRegion",
+          null,
+          "AWS region for ElastiCache IAM authentication.");
+
+  protected static final AwsWrapperProperty CACHE_USERNAME =
+      new AwsWrapperProperty(
+          "cacheUsername",
+          null,
+          "Username for ElastiCache regular authentication.");
+
+  protected static final AwsWrapperProperty CACHE_PASSWORD =
+      new AwsWrapperProperty(
+          "cachePassword",
+          null,
+          "Password for ElastiCache regular authentication.");
+
+  protected static final AwsWrapperProperty CACHE_NAME =
+      new AwsWrapperProperty(
+          "cacheName",
+          null,
+          "Explicit cache name for ElastiCache IAM authentication. ");
+
   private final boolean useSSL;
+  private final boolean iamAuthEnabled;
+  private final String cacheIamRegion;
+  private final String cacheUsername;
+  private final String cacheName;
+  private final String cachePassword;
+  private final Properties awsProfileProperties;
+  private final AwsCredentialsProvider credentialsProvider;
 
   static {
     PropertyDefinition.registerPluginProperties(CacheConnection.class);
@@ -71,6 +130,44 @@ public class CacheConnection {
     this.cacheRwServerAddr = CACHE_RW_ENDPOINT_ADDR.getString(properties);
     this.cacheRoServerAddr = CACHE_RO_ENDPOINT_ADDR.getString(properties);
     this.useSSL = Boolean.parseBoolean(CACHE_USE_SSL.getString(properties));
+    this.cacheName = CACHE_NAME.getString(properties);
+    this.cacheIamRegion = CACHE_IAM_REGION.getString(properties);
+    this.cacheUsername = CACHE_USERNAME.getString(properties);
+    this.cachePassword = CACHE_PASSWORD.getString(properties);
+    this.iamAuthEnabled = !StringUtils.isNullOrEmpty(this.cacheIamRegion);
+    boolean hasTraditionalAuth = !StringUtils.isNullOrEmpty(this.cachePassword);
+    // Validate authentication configuration
+    if (this.iamAuthEnabled && hasTraditionalAuth) {
+      throw new IllegalArgumentException(
+          "Cannot specify both IAM authentication (cacheIamRegion) and traditional authentication (cachePassword). Choose one authentication method.");
+    }
+    if (this.cacheRwServerAddr == null) {
+      throw new IllegalArgumentException("Cache endpoint address is required");
+    }
+    this.defaultCacheServerHostAndPort = getHostnameAndPort(this.cacheRwServerAddr);
+    if (this.iamAuthEnabled) {
+      if (this.cacheUsername == null || this.defaultCacheServerHostAndPort[0] == null || this.cacheName == null) {
+        throw new IllegalArgumentException("IAM authentication requires cache name, username, region, and hostname");
+      }
+    }
+    if (PropertyDefinition.AWS_PROFILE.getString(properties) != null) {
+      this.awsProfileProperties = new Properties();
+      this.awsProfileProperties.setProperty(
+          PropertyDefinition.AWS_PROFILE.name,
+          PropertyDefinition.AWS_PROFILE.getString(properties)
+      );
+    } else {
+      this.awsProfileProperties = null;
+    }
+    if (this.iamAuthEnabled) {
+      // Handle null case
+      Properties propsToPass = (this.awsProfileProperties != null)
+          ? this.awsProfileProperties
+          : new Properties();
+      this.credentialsProvider = AwsCredentialsManager.getProvider(null, propsToPass);
+    } else {
+      this.credentialsProvider = null;
+    }
   }
 
   /* Here we check if we need to initialise connection pool for read or write to cache.
@@ -113,15 +210,14 @@ public class CacheConnection {
       if (isRead && !StringUtils.isNullOrEmpty(cacheRoServerAddr)) {
         serverAddr = cacheRoServerAddr;
       }
-      String[] hostnameAndPort = serverAddr.split(":");
-      RedisURI redisUriCluster = RedisURI.Builder.redis(hostnameAndPort[0])
-          .withPort(Integer.parseInt(hostnameAndPort[1]))
-          .withSsl(useSSL).withVerifyPeer(false).withLibraryName("aws-sql-jdbc-lettuce").build();
+      String[] hostnameAndPort = getHostnameAndPort(serverAddr);
+      RedisURI redisUriCluster = buildRedisURI(hostnameAndPort[0], Integer.parseInt(hostnameAndPort[1]));
 
       RedisClient client = RedisClient.create(resources, redisUriCluster);
       GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> pool = new GenericObjectPool<>(
           new BasePooledObjectFactory<StatefulRedisConnection<byte[], byte[]>>() {
             public StatefulRedisConnection<byte[], byte[]> create() {
+
               StatefulRedisConnection<byte[], byte[]> connection = client.connect(new ByteArrayCodec());
               // In cluster mode, we need to send READONLY command to the server for reading from replica.
               // Note: we gracefully ignore ERR reply to support non cluster mode.
@@ -148,7 +244,6 @@ public class CacheConnection {
       } else {
         writeConnectionPool = pool;
       }
-
     } catch (Exception e) {
       String poolType = isRead ? "read" : "write";
       String errorMsg = String.format("Failed to create Cache %s connection pool", poolType);
@@ -247,13 +342,13 @@ public class CacheConnection {
   private void returnConnectionBackToPool(StatefulRedisConnection <byte[], byte[]> connection, boolean isConnectionBroken, boolean isRead) {
     GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> pool = isRead ? readConnectionPool : writeConnectionPool;
     if (isConnectionBroken) {
-        try {
-          pool.invalidateObject(connection);
-        } catch (Exception e) {
-          throw new RuntimeException("Could not invalidate connection for the pool", e);
-        }
+      try {
+        pool.invalidateObject(connection);
+      } catch (Exception e) {
+        throw new RuntimeException("Could not invalidate connection for the pool", e);
+      }
     } else {
-        pool.returnObject(connection);
+      pool.returnObject(connection);
     }
   }
 
@@ -262,5 +357,44 @@ public class CacheConnection {
       GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> writePool) {
     readConnectionPool = readPool;
     writeConnectionPool = writePool;
+  }
+
+  protected RedisURI buildRedisURI(String hostname, int port) {
+    RedisURI.Builder uriBuilder = RedisURI.Builder.redis(hostname)
+        .withPort(port)
+        .withSsl(useSSL)
+        .withVerifyPeer(false)
+        .withLibraryName("aws-sql-jdbc-lettuce");
+
+    if (this.iamAuthEnabled) {
+      // Create a credentials provider that Lettuce will call whenever authentication is needed
+      RedisCredentialsProvider credentialsProvider = () -> {
+        // Create a cached token supplier that automatically refreshes tokens every 14.5 minutes
+        Supplier<String> tokenSupplier = CachedSupplier.memoizeWithExpiration(
+            () -> {
+              ElastiCacheIamTokenUtility tokenUtility = new ElastiCacheIamTokenUtility(this.cacheName);
+              return tokenUtility.generateAuthenticationToken(
+                  this.credentialsProvider,
+                  Region.of(this.cacheIamRegion),
+                  this.defaultCacheServerHostAndPort[0],
+                  Integer.parseInt(this.defaultCacheServerHostAndPort[1]),
+                  this.cacheUsername
+              );
+            },
+            TOKEN_CACHE_DURATION,
+            TimeUnit.SECONDS
+        );
+        // Package the username and token (from cache or freshly generated) into Redis credentials
+        return Mono.just(RedisCredentials.just(this.cacheUsername, tokenSupplier.get()));
+      };
+      uriBuilder.withAuthentication(credentialsProvider);
+    } else if (!StringUtils.isNullOrEmpty(this.cachePassword)) {
+      uriBuilder.withAuthentication(this.cacheUsername, this.cachePassword);
+    }
+    return uriBuilder.build();
+  }
+
+  private String[] getHostnameAndPort(String serverAddr) {
+    return serverAddr.split(":");
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CachedSupplier.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CachedSupplier.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.cache;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+
+public final class CachedSupplier {
+
+  private CachedSupplier() {
+    throw new UnsupportedOperationException("Utility class should not be instantiated");
+  }
+
+  public static <T> Supplier<T> memoizeWithExpiration(
+      Supplier<T> delegate, long duration, TimeUnit unit) {
+
+    Objects.requireNonNull(delegate, "delegate Supplier must not be null");
+    Objects.requireNonNull(unit, "TimeUnit must not be null");
+    if (duration <= 0) {
+      throw new IllegalArgumentException("duration must be > 0");
+    }
+
+    return new ExpiringMemoizingSupplier<>(delegate, duration, unit);
+  }
+
+  private static final class ExpiringMemoizingSupplier<T> implements Supplier<T> {
+
+    private final Supplier<T> delegate;
+    private final long durationNanos;
+    private final ReentrantLock lock = new ReentrantLock();
+
+    private volatile T value;
+    private volatile long expirationNanos; // 0 means not yet initialized
+
+    ExpiringMemoizingSupplier(Supplier<T> delegate, long duration, TimeUnit unit) {
+      this.delegate = delegate;
+      this.durationNanos = unit.toNanos(duration);
+    }
+
+    @Override
+    public T get() {
+      long now = System.nanoTime();
+
+      // Check if value is expired or uninitialized
+      if (expirationNanos == 0 || now - expirationNanos >= 0) {
+        lock.lock();
+        try {
+          if (expirationNanos == 0 || now - expirationNanos >= 0) {
+            value = delegate.get();
+            long next = now + durationNanos;
+            expirationNanos = (next == 0) ? 1 : next; // avoid 0 sentinel
+          }
+        } finally {
+          lock.unlock();
+        }
+      }
+      return value;
+    }
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/iam/ElastiCacheIamTokenUtility.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/iam/ElastiCacheIamTokenUtility.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.iam;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Objects;
+import java.util.logging.Logger;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.CredentialUtils;
+import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.auth.signer.params.Aws4PresignerParams;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
+import software.amazon.awssdk.utils.StringUtils;
+
+public class ElastiCacheIamTokenUtility implements IamTokenUtility {
+
+  private static final Logger LOGGER = Logger.getLogger(ElastiCacheIamTokenUtility.class.getName());
+  private static final String PARAM_ACTION = "Action";
+  private static final String PARAM_USER = "User";
+  private static final String ACTION_NAME = "connect";
+  private static final String PARAM_RESOURCE_TYPE = "ResourceType";
+  private static final String RESOURCE_TYPE_SERVERLESS_CACHE = "ServerlessCache";
+  private static final String SERVICE_NAME = "elasticache";
+  private static final String PROTOCOL = "http";
+  private static final Duration EXPIRATION_DURATION = Duration.ofSeconds(15 * 60 - 30);
+  public static final String SERVERLESS_CACHE_IDENTIFIER = ".serverless.";
+
+  private final Clock clock;
+  private String cacheName = null;
+  private final Aws4Signer signer;
+
+  public ElastiCacheIamTokenUtility(String cacheName) {
+    this.cacheName = Objects.requireNonNull(cacheName, "cacheName cannot be null");
+    this.clock = Clock.systemUTC();
+    this.signer = Aws4Signer.create();
+  }
+
+  // For testing only
+  public ElastiCacheIamTokenUtility(String cacheName, Instant fixedInstant, Aws4Signer signer) {
+    this.cacheName = Objects.requireNonNull(cacheName, "cacheName cannot be null");
+    this.clock = Clock.fixed(fixedInstant, ZoneId.of("UTC"));
+    this.signer = signer;
+  }
+
+  @Override
+  public String generateAuthenticationToken(
+      final @NonNull AwsCredentialsProvider credentialsProvider,
+      final @NonNull Region region,
+      final @NonNull String hostname,
+      final int port,
+      final @NonNull String username) {
+
+    boolean isServerless = isServerlessCache(hostname);
+    if (this.cacheName == null) {
+      throw new IllegalArgumentException("Cache name cannot be null for cache with IAM authentication");
+    }
+
+    SdkHttpFullRequest.Builder requestBuilder = SdkHttpFullRequest.builder()
+        .method(SdkHttpMethod.GET)
+        .protocol(PROTOCOL) // ElastiCache uses http, not https
+        .host(this.cacheName)
+        .encodedPath("/")
+        .putRawQueryParameter(PARAM_ACTION, ACTION_NAME)
+        .putRawQueryParameter(PARAM_USER, username);
+
+    if (isServerless) {
+      requestBuilder.putRawQueryParameter(PARAM_RESOURCE_TYPE, RESOURCE_TYPE_SERVERLESS_CACHE);
+    }
+
+    final SdkHttpFullRequest httpRequest = requestBuilder.build();
+
+    final Instant expirationTime = Instant.now(this.clock).plus(EXPIRATION_DURATION);
+
+    final AwsCredentials credentials = CredentialUtils.toCredentials(
+        CompletableFutureUtils.joinLikeSync(credentialsProvider.resolveIdentity()));
+
+    final Aws4PresignerParams presignRequest = Aws4PresignerParams.builder()
+        .signingClockOverride(this.clock)
+        .expirationTime(expirationTime)
+        .awsCredentials(credentials)
+        .signingName(SERVICE_NAME)
+        .signingRegion(region)
+        .build();
+
+    final SdkHttpFullRequest fullRequest = this.signer.presign(httpRequest, presignRequest);
+    final String signedUrl = fullRequest.getUri().toString();
+
+    // Format should be:
+    // Regular: <cache-name>/?Action=connect&User=<username>&X-Amz-Security-Token=...&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=...&X-Amz-SignedHeaders=host&X-Amz-Expires=870&X-Amz-Credential=...&X-Amz-Signature=...
+    // Serverless: <cache-name>/?Action=connect&User=<username>&ResourceType=ServerlessCache&X-Amz-Security-Token=...&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=...&X-Amz-SignedHeaders=host&X-Amz-Expires=870&X-Amz-Credential=...&X-Amz-Signature=...
+    // Note: This must be the real ElastiCache hostname, not proxy or tunnels
+    final String result = StringUtils.replacePrefixIgnoreCase(signedUrl, "http://", "");
+    LOGGER.finest(() -> "Generated ElastiCache authentication token with expiration of " + expirationTime);
+    return result;
+  }
+
+  private boolean isServerlessCache(String hostname) {
+    if (hostname == null) {
+      throw new IllegalArgumentException("Hostname cannot be null");
+    }
+    return hostname.contains(SERVERLESS_CACHE_IDENTIFIER);
+  }
+}

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CacheConnectionTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CacheConnectionTest.java
@@ -1,9 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package software.amazon.jdbc.plugin.cache;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-
 import io.lettuce.core.RedisFuture;
+import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.api.sync.RedisCommands;
@@ -12,11 +26,17 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
 import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.jdbc.plugin.iam.ElastiCacheIamTokenUtility;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.function.BiConsumer;
 import java.util.Properties;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 public class CacheConnectionTest {
@@ -43,6 +63,242 @@ public class CacheConnectionTest {
   @AfterEach
   void cleanUp() throws Exception {
     closeable.close();
+  }
+
+  @Test
+  void testIamAuth_PropertyExtraction() throws Exception {
+    Properties props = new Properties();
+    props.setProperty("cacheEndpointAddrRw", "test-cache.cache.amazonaws.com:6379");
+    props.setProperty("cacheIamRegion", "us-west-2");
+    props.setProperty("cacheUsername", "myuser");
+    props.setProperty("cacheName", "my-cache");
+
+    CacheConnection connection = new CacheConnection(props);
+
+    // Verify all IAM fields are set correctly
+    assertEquals("us-west-2", getField(connection, "cacheIamRegion"));
+    assertEquals("myuser", getField(connection, "cacheUsername"));
+    assertEquals("my-cache", getField(connection, "cacheName"));
+  }
+
+  @Test
+  void testIamAuth_PropertyExtractionTraditional() throws Exception {
+    Properties props = new Properties();
+    props.setProperty("cacheEndpointAddrRw", "test-cache.cache.amazonaws.com:6379");
+    props.setProperty("cacheUsername", "myuser");
+    props.setProperty("cachePassword", "password");
+    props.setProperty("cacheName", "my-cache");
+
+    CacheConnection connection = new CacheConnection(props);
+
+    // Verify all IAM fields are set correctly
+    assertEquals("myuser", getField(connection, "cacheUsername"));
+    assertEquals("my-cache", getField(connection, "cacheName"));
+    assertEquals("password", getField(connection, "cachePassword"));
+  }
+
+  @Test
+  void testIamAuthEnabled_WhenRegionProvided() throws Exception {
+    Properties props = new Properties();
+    props.setProperty("cacheEndpointAddrRw", "test.cache.amazonaws.com:6379");
+    props.setProperty("cacheIamRegion", "us-east-1");
+    props.setProperty("cacheUsername", "testuser");
+    props.setProperty("cacheName", "my-cache");
+
+    CacheConnection connection = new CacheConnection(props);
+
+    // Use reflection to verify iamAuthEnabled is true
+    Field field = CacheConnection.class.getDeclaredField("iamAuthEnabled");
+    field.setAccessible(true);
+    assertTrue((boolean) field.get(connection));
+    // Verify all IAM fields are set correctly
+    assertEquals("us-east-1", getField(connection, "cacheIamRegion"));
+    assertEquals("testuser", getField(connection, "cacheUsername"));
+    assertEquals("my-cache", getField(connection, "cacheName"));
+  }
+
+  @Test
+  void testConstructor_IamAuthEnabled_MissingCacheName() {
+    Properties props = new Properties();
+    props.setProperty("cacheEndpointAddrRw", "test-cache.cache.amazonaws.com:6379");
+    props.setProperty("cacheIamRegion", "us-west-2");
+    props.setProperty("cacheUsername", "myuser");
+    // Missing cacheName property
+
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> new CacheConnection(props)
+    );
+
+    assertTrue(exception.getMessage().contains("IAM authentication requires cache name, username, region, and hostname"));
+  }
+
+  @Test
+  void testTraditionalAuth_WhenNoIamRegion() throws Exception {
+    Properties props = new Properties();
+    props.setProperty("cacheEndpointAddrRw", "localhost:6379");
+    props.setProperty("cacheUsername", "user");
+    props.setProperty("cachePassword", "pass");
+
+    CacheConnection connection = new CacheConnection(props);
+
+    assertFalse((boolean) getField(connection, "iamAuthEnabled"));
+    assertNull(getField(connection, "credentialsProvider"));
+    assertEquals("user", getField(connection, "cacheUsername"));
+    assertEquals("pass", getField(connection, "cachePassword"));
+  }
+
+  @Test
+  void testConstructor_NoRwAddress() {
+    Properties props = new Properties();
+    props.setProperty("wrapperPlugins", "dataRemoteCache");
+    props.setProperty("cacheEndpointAddrRo", "localhost:6379");
+
+    assertThrows(IllegalArgumentException.class, () -> new CacheConnection(props));
+  }
+
+  @Test
+  void testConstructor_IamAuthEnabled_MissingCacheUsername() {
+    Properties props = new Properties();
+    props.setProperty("cacheEndpointAddrRw", "test-cache.cache.amazonaws.com:6379");
+    props.setProperty("cacheIamRegion", "us-east-1");
+
+    assertThrows(IllegalArgumentException.class, () -> new CacheConnection(props));
+  }
+
+  @Test
+  void testConstructor_ConflictingAuthenticationMethods() {
+    Properties props = new Properties();
+    props.setProperty("cacheEndpointAddrRw", "test-cache.cache.amazonaws.com:6379");
+    props.setProperty("cacheIamRegion", "us-west-2");  // IAM auth
+    props.setProperty("cacheUsername", "myuser");
+    props.setProperty("cachePassword", "mypassword");  // Traditional auth
+    props.setProperty("cacheName", "my-cache");
+
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> new CacheConnection(props)
+    );
+
+    assertTrue(exception.getMessage().contains("Cannot specify both IAM authentication"));
+  }
+
+  @Test
+  void testAwsCredentialsProvider_WithProfile() throws Exception {
+    Properties props = new Properties();
+    props.setProperty("cacheEndpointAddrRw", "test.cache.amazonaws.com:6379");
+    props.setProperty("cacheIamRegion", "us-east-1");
+    props.setProperty("cacheUsername", "testuser");
+    props.setProperty("cacheName", "my-cache");
+    props.setProperty("awsProfile", "test-profile");
+
+    CacheConnection connection = new CacheConnection(props);
+
+    // Verify the awsProfileProperties field contains the correct profile
+    Properties awsProfileProps = (Properties) getField(connection, "awsProfileProperties");
+    assertEquals("test-profile", awsProfileProps.getProperty("awsProfile"));
+
+    assertEquals("my-cache", getField(connection, "cacheName"));
+    assertEquals("testuser", getField(connection, "cacheUsername"));
+    assertEquals("us-east-1", getField(connection, "cacheIamRegion"));
+    assertEquals("test.cache.amazonaws.com:6379", getField(connection, "cacheRwServerAddr"));
+  }
+
+  @Test
+  void testAwsCredentialsProvider_WithoutProfile() throws Exception {
+    Properties props = new Properties();
+    props.setProperty("cacheEndpointAddrRw", "test.cache.amazonaws.com:6379");
+    props.setProperty("cacheIamRegion", "us-east-1");
+    props.setProperty("cacheUsername", "testuser");
+    props.setProperty("cacheName", "my-cache");
+    // No awsProfile property
+
+    CacheConnection connection = new CacheConnection(props);
+
+    // Verify awsProfileProperties is not empty when no profile specified
+    Properties awsProfileProps = (Properties) getField(connection, "awsProfileProperties");
+    assertNull(awsProfileProps);
+
+    assertEquals("my-cache", getField(connection, "cacheName"));
+    assertEquals("testuser", getField(connection, "cacheUsername"));
+    assertEquals("us-east-1", getField(connection, "cacheIamRegion"));
+    assertEquals("test.cache.amazonaws.com:6379", getField(connection, "cacheRwServerAddr"));
+  }
+
+  @Test
+  void testBuildRedisURI_IamAuth() {
+    Properties props = new Properties();
+    props.setProperty("cacheEndpointAddrRw", "test-cache.cache.amazonaws.com:6379");
+    props.setProperty("cacheIamRegion", "us-east-1");
+    props.setProperty("cacheUsername", "testuser");
+    props.setProperty("cacheName", "test-cache");
+
+    try (MockedConstruction<ElastiCacheIamTokenUtility> mockedTokenUtility = mockConstruction(ElastiCacheIamTokenUtility.class)) {
+
+      CacheConnection connection = new CacheConnection(props);
+      RedisURI uri = connection.buildRedisURI("test-cache.cache.amazonaws.com", 6379);
+
+      // Verify URI properties
+      assertNotNull(uri);
+      assertEquals("test-cache.cache.amazonaws.com", uri.getHost());
+      assertEquals(6379, uri.getPort());
+      assertTrue(uri.isSsl());
+      assertNotNull(uri.getCredentialsProvider());
+
+      // Trigger the credentials provider to create the token utility
+      uri.getCredentialsProvider().resolveCredentials().block();
+
+      // Verify URI properties
+      assertNotNull(uri);
+      assertEquals("test-cache.cache.amazonaws.com", uri.getHost());
+      assertEquals(6379, uri.getPort());
+      assertTrue(uri.isSsl());
+      assertNotNull(uri.getCredentialsProvider()); // IAM credentials provider set
+
+      // Verify ElastiCacheIamTokenUtility was constructed with correct parameters
+      // Verify token utility construction
+      assertEquals(1, mockedTokenUtility.constructed().size());
+      ElastiCacheIamTokenUtility tokenUtility = mockedTokenUtility.constructed().get(0);
+      verify(tokenUtility).generateAuthenticationToken(
+          any(AwsCredentialsProvider.class),
+          eq(Region.US_EAST_1),
+          eq("test-cache.cache.amazonaws.com"),
+          eq(6379),
+          eq("testuser")
+      );
+    }
+  }
+
+  @Test
+  void testBuildRedisURI_TraditionalAuth() {
+    Properties props = new Properties();
+    props.setProperty("cacheEndpointAddrRw", "localhost:6379");
+    props.setProperty("cacheUsername", "user");
+    props.setProperty("cachePassword", "pass");
+
+    CacheConnection connection = new CacheConnection(props);
+    RedisURI uri = connection.buildRedisURI("localhost", 6379);
+
+    assertNotNull(uri);
+    assertEquals("localhost", uri.getHost());
+    assertEquals(6379, uri.getPort());
+    assertEquals("user", uri.getUsername());
+    assertEquals("pass", new String(uri.getPassword()));
+  }
+
+  @Test
+  void testBuildRedisURI_NoAuth() {
+    Properties props = new Properties();
+    props.setProperty("cacheEndpointAddrRw", "localhost:6379");
+
+    CacheConnection connection = new CacheConnection(props);
+    RedisURI uri = connection.buildRedisURI("localhost", 6379);
+
+    assertNotNull(uri);
+    assertEquals("localhost", uri.getHost());
+    assertEquals(6379, uri.getPort());
+    assertNull(uri.getUsername());
+    assertNull(uri.getPassword());
   }
 
   @Test
@@ -106,5 +362,11 @@ public class CacheConnectionTest {
     verify(mockConnection).sync();
     verify(mockSyncCommands).get(any());
     verify(mockReadConnPool).invalidateObject(mockConnection);
+  }
+
+  private Object getField(Object obj, String fieldName) throws Exception {
+    Field field = obj.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return field.get(obj);
   }
 }

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CacheSupplierTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CacheSupplierTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.cache;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+public class CacheSupplierTest {
+
+  @Test
+  void testMemoizeWithExpiration_ValidParameters() {
+    Supplier<String> delegate = () -> "test-value";
+
+    Supplier<String> cached = CachedSupplier.memoizeWithExpiration(delegate, 1, TimeUnit.SECONDS);
+
+    assertNotNull(cached);
+    assertEquals("test-value", cached.get());
+  }
+
+  @Test
+  void testMemoizeWithExpiration_NullDelegate() {
+    assertThrows(NullPointerException.class, () ->
+        CachedSupplier.memoizeWithExpiration(null, 1, TimeUnit.SECONDS));
+  }
+
+  @Test
+  void testMemoizeWithExpiration_NullTimeUnit() {
+    Supplier<String> delegate = () -> "test";
+
+    assertThrows(NullPointerException.class, () ->
+        CachedSupplier.memoizeWithExpiration(delegate, 1, null));
+  }
+
+  @Test
+  void testMemoizeWithExpiration_ZeroDuration() {
+    Supplier<String> delegate = () -> "test";
+
+    assertThrows(IllegalArgumentException.class, () ->
+        CachedSupplier.memoizeWithExpiration(delegate, 0, TimeUnit.SECONDS));
+  }
+
+  @Test
+  void testMemoizeWithExpiration_NegativeDuration() {
+    Supplier<String> delegate = () -> "test";
+
+    assertThrows(IllegalArgumentException.class, () ->
+        CachedSupplier.memoizeWithExpiration(delegate, -1, TimeUnit.SECONDS));
+  }
+
+  @Test
+  void testCaching_DelegateCalledOnce() {
+    Supplier<String> mockDelegate = mock(Supplier.class);
+    when(mockDelegate.get()).thenReturn("cached-value");
+
+    Supplier<String> cached = CachedSupplier.memoizeWithExpiration(mockDelegate, 1, TimeUnit.SECONDS);
+
+    // Call multiple times quickly
+    assertEquals("cached-value", cached.get());
+    assertEquals("cached-value", cached.get());
+    assertEquals("cached-value", cached.get());
+
+    // Delegate should only be called once due to caching
+    verify(mockDelegate, times(1)).get();
+  }
+
+  @Test
+  void testExpiration_DelegateCalledAgainAfterExpiry() throws InterruptedException {
+    Supplier<String> mockDelegate = mock(Supplier.class);
+    when(mockDelegate.get()).thenReturn("value1", "value2");
+
+    Supplier<String> cached = CachedSupplier.memoizeWithExpiration(mockDelegate, 50, TimeUnit.MILLISECONDS);
+
+    // First call
+    assertEquals("value1", cached.get());
+    verify(mockDelegate, times(1)).get();
+
+    // Wait for expiration
+    Thread.sleep(100);
+
+    // Second call after expiration
+    assertEquals("value2", cached.get());
+    verify(mockDelegate, times(2)).get();
+  }
+
+  @Test
+  void testConcurrentAccess() throws InterruptedException {
+    Supplier<String> mockDelegate = mock(Supplier.class);
+    when(mockDelegate.get()).thenReturn("concurrent-value");
+
+    Supplier<String> cached = CachedSupplier.memoizeWithExpiration(mockDelegate, 5, TimeUnit.SECONDS);
+
+    // Simulate concurrent access
+    Thread[] threads = new Thread[10];
+    String[] results = new String[10];
+
+    for (int i = 0; i < 10; i++) {
+      final int index = i;
+      threads[i] = new Thread(() -> results[index] = cached.get());
+      threads[i].start();
+    }
+
+    // Wait for all threads
+    for (Thread thread : threads) {
+      thread.join();
+    }
+
+    // All should get the same cached value
+    for (String result : results) {
+      assertEquals("concurrent-value", result);
+    }
+
+    // Delegate should only be called once despite concurrent access
+    verify(mockDelegate, times(1)).get();
+  }
+
+  @Test
+  void testExpirationNanos_EdgeCase() {
+    Supplier<Long> timeSupplier = () -> System.nanoTime();
+
+    Supplier<Long> cached = CachedSupplier.memoizeWithExpiration(timeSupplier, 1, TimeUnit.NANOSECONDS);
+
+    Long first = cached.get();
+    Long second = cached.get();
+
+    // Due to very short expiration, second call might get different value
+    assertNotNull(first);
+    assertNotNull(second);
+  }
+
+  @Test
+  void testPrivateConstructor() {
+    // Verify utility class has private constructor
+    assertThrows(Exception.class, () -> {
+      java.lang.reflect.Constructor<CachedSupplier> constructor =
+          CachedSupplier.class.getDeclaredConstructor();
+      constructor.setAccessible(true);
+      constructor.newInstance();
+    });
+  }
+}

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/iam/ElastiCacheIamTokenUtilityTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/iam/ElastiCacheIamTokenUtilityTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.iam;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.auth.signer.params.Aws4PresignerParams;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.regions.Region;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+
+public class ElastiCacheIamTokenUtilityTest {
+  @Mock private AwsCredentialsProvider mockCredentialsProvider;
+  @Mock private AwsCredentials mockCredentials;
+  @Mock private Aws4Signer mockSigner;
+  @Mock private SdkHttpFullRequest mockSignedRequest;
+
+  private AutoCloseable closeable;
+  private ElastiCacheIamTokenUtility tokenUtility;
+  private final Instant fixedInstant = Instant.parse("2025-01-01T12:00:00Z");
+
+  @BeforeEach
+  void setUp() {
+    closeable = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    closeable.close();
+  }
+
+  @Test
+  void testConstructor_WithCacheName() {
+    tokenUtility = new ElastiCacheIamTokenUtility("test-cache");
+    assertNotNull(tokenUtility);
+  }
+
+  @Test
+  void testConstructor_WithCacheNameAndFixedInstant() {
+    tokenUtility = new ElastiCacheIamTokenUtility("test-cache", fixedInstant, mockSigner);
+    assertNotNull(tokenUtility);
+  }
+
+  @Test
+  void testConstructor_NullCacheName() {
+    assertThrows(NullPointerException.class, () ->
+        new ElastiCacheIamTokenUtility(null));
+  }
+
+  @Test
+  void testConstructor_NullCacheNameWithInstant() {
+    assertThrows(NullPointerException.class, () ->
+        new ElastiCacheIamTokenUtility(null, fixedInstant, mockSigner));
+  }
+
+    @Test
+    void testGenerateAuthenticationToken_RegularCache() {
+      // Setup mock credentials provider to return mockCredentials
+      when(mockCredentialsProvider.resolveIdentity())
+        .thenReturn((CompletableFuture) CompletableFuture.completedFuture(mockCredentials));
+
+      // Add custom presign behavior to capture and verify arguments
+      when(mockSigner.presign(any(SdkHttpFullRequest.class), any(Aws4PresignerParams.class)))
+        .thenAnswer(invocation -> {
+          SdkHttpFullRequest request = invocation.getArgument(0);
+          Aws4PresignerParams presignParams = invocation.getArgument(1);
+
+          // Verify SdkHttpFullRequest
+          assertEquals("test-cache", request.host());
+          assertEquals("/", request.encodedPath());
+          assertEquals("connect", request.rawQueryParameters().get("Action").get(0));
+          assertEquals("testuser", request.rawQueryParameters().get("User").get(0));
+          assertFalse(request.rawQueryParameters().containsKey("ResourceType"));
+
+          // Verify Aws4PresignerParams
+          assertEquals("elasticache", presignParams.signingName());
+          assertEquals(Region.US_EAST_1, presignParams.signingRegion());
+          assertEquals(mockCredentials, presignParams.awsCredentials());
+
+          Instant expectedExpiration = fixedInstant.plus(Duration.ofSeconds(15 * 60 - 30));
+          assertEquals(expectedExpiration, presignParams.expirationTime().get());
+          assertEquals(fixedInstant, presignParams.signingClockOverride().get().instant());
+
+          return mockSignedRequest;
+        });
+
+      when(mockSignedRequest.getUri()).thenReturn(java.net.URI.create("http://test-cache/result"));
+
+      tokenUtility = new ElastiCacheIamTokenUtility("test-cache", fixedInstant, mockSigner);
+
+      String token = tokenUtility.generateAuthenticationToken(
+        mockCredentialsProvider, Region.US_EAST_1, "test-cache.cache.amazonaws.com", 6379, "testuser");
+
+      assertEquals("test-cache/result", token);
+      verify(mockSigner).presign(any(SdkHttpFullRequest.class), any(Aws4PresignerParams.class));
+    }
+
+  @Test
+  void testGenerateAuthenticationToken_ServerlessCache() {
+    // Setup mock credentials provider to return mockCredentials
+    when(mockCredentialsProvider.resolveIdentity())
+            .thenReturn((CompletableFuture) CompletableFuture.completedFuture(mockCredentials));
+
+    // Add custom presign behavior to capture and verify arguments
+    when(mockSigner.presign(any(SdkHttpFullRequest.class), any(Aws4PresignerParams.class)))
+      .thenAnswer(invocation -> {
+        SdkHttpFullRequest request = invocation.getArgument(0);
+        Aws4PresignerParams presignParams = invocation.getArgument(1);
+
+        // Verify SdkHttpFullRequest
+        assertEquals("test-cache", request.host());
+        assertEquals("/", request.encodedPath());
+        assertEquals("connect", request.rawQueryParameters().get("Action").get(0));
+        assertEquals("testuser", request.rawQueryParameters().get("User").get(0));
+        assertEquals("ServerlessCache", request.rawQueryParameters().get("ResourceType").get(0));
+
+        // Verify Aws4PresignerParams
+        assertEquals("elasticache", presignParams.signingName());
+        assertEquals(Region.US_EAST_1, presignParams.signingRegion());
+        assertEquals(mockCredentials, presignParams.awsCredentials());
+
+        Instant expectedExpiration = fixedInstant.plus(Duration.ofSeconds(15 * 60 - 30));
+        assertEquals(expectedExpiration, presignParams.expirationTime().get());
+        assertEquals(fixedInstant, presignParams.signingClockOverride().get().instant());
+
+        return mockSignedRequest;
+      });
+
+    when(mockSignedRequest.getUri()).thenReturn(java.net.URI.create("http://test-cache.serverless.cache.amazonaws.com/result"));
+
+    tokenUtility = new ElastiCacheIamTokenUtility("test-cache", fixedInstant, mockSigner);
+
+    String token = tokenUtility.generateAuthenticationToken(
+        mockCredentialsProvider, Region.US_EAST_1, "test-cache.serverless.cache.amazonaws.com", 6379, "testuser");
+
+    assertEquals("test-cache.serverless.cache.amazonaws.com/result", token);
+    verify(mockSigner).presign(any(SdkHttpFullRequest.class), any(Aws4PresignerParams.class));
+  }
+
+  @Test
+  void testGenerateAuthenticationToken_NullCacheName() {
+    tokenUtility = new ElastiCacheIamTokenUtility("test-cache", fixedInstant, mockSigner);
+
+    // Use reflection to set cacheName to null to test the validation
+    try {
+      java.lang.reflect.Field field = ElastiCacheIamTokenUtility.class.getDeclaredField("cacheName");
+      field.setAccessible(true);
+      field.set(tokenUtility, null);
+
+      assertThrows(IllegalArgumentException.class, () ->
+          tokenUtility.generateAuthenticationToken(
+              mockCredentialsProvider, Region.US_EAST_1, "test-host", 6379, "testuser"));
+    } catch (Exception e) {
+      fail("Reflection failed: " + e.getMessage());
+    }
+  }
+
+  @Test
+  void testGenerateAuthenticationToken_NullHostname() {
+    tokenUtility = new ElastiCacheIamTokenUtility("test-cache", fixedInstant, mockSigner);
+
+    assertThrows(IllegalArgumentException.class, () ->
+        tokenUtility.generateAuthenticationToken(
+            mockCredentialsProvider, Region.US_EAST_1, null, 6379, "testuser"));
+  }
+}


### PR DESCRIPTION
### Summary

Add ElastiCache IAM Authentication Support to AWS Advanced JDBC Wrapper

### Description

This PR implements IAM authentication for ElastiCache Valkey clusters in the DataRemoteCachePlugin, enabling seamless authentication using AWS credentials with automatic token refresh and caching.

Key Changes:

1. `ElastiCacheIamTokenUtility.java` (New)
  • Implements IamTokenUtility interface for ElastiCache-specific IAM token generation
  • Auto-detects serverless vs regular cache clusters from hostname patterns (`.serverless.`)
  • Uses provided cache name to generate 15-minute authentication tokens
  • Uses AWS SDK v2 for presigned URL generation with ElastiCache service endpoints

2. `CachedSupplier.java` (New)
  • Utility class providing `memoizeWithExpiration()` method for automatic token caching
  • Thread-safe implementation using `ReentrantLock` for concurrent access
  • Replaces Guava's `Suppliers.memoizeWithExpiration()` to eliminate external dependencies
  • Handles token expiration and automatic refresh with configurable duration

3. `CacheConnection.java`
  • Added IAM authentication properties (`CACHE_USERNAME`, `CACHE_IAM_REGION`, `CACHE_NAME`, etc.)
  • Enhanced `createConnectionPool()` with inline `RedisCredentialsProvider` implementation for re-auth
  • Uses `CachedSupplier.memoizeWithExpiration()` for 14.5-minute token caching (15 min - 30s buffer)
  • Supports three authentication modes: IAM, traditional username/password, and no-auth
  • Lettuce automatically handles re-authentication through the credentials provider pattern

Authentication Flow:

• Detects ElastiCache endpoints during `CacheConnection` initialization
• Creates inline `RedisCredentialsProvider` that uses `CachedSupplier` for token management
• Lettuce automatically calls `resolveCredentials()` when authentication is needed
• Tokens are cached for 14.5 minutes and refreshed automatically on expiration

Configuration Example:

```
cacheUsername=my-iam-user
cacheIamRegion=us-west-2
cacheName=my-cache-cluster
cacheEndpointAddrRw=my-cache.cache.amazonaws.com:6379
```

This implementation provides automatic IAM token refresh and re-authentication for ElastiCache without external dependencies, using a custom `CachedSupplier` utility for token lifecycle management.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
