### PR TITLE
[Draft] Add cacheFailOnError configuration for cache failure handling

### DIFF
--- a/examples/AWSDriverExample/src/main/java/software/amazon/SQLCachingDemo.java
+++ b/examples/AWSDriverExample/src/main/java/software/amazon/SQLCachingDemo.java
@@ -1,0 +1,137 @@
+package software.amazon;
+
+import software.amazon.util.EnvLoader;
+import java.sql.*;
+import java.util.*;
+import java.util.logging.Logger;
+
+public class SQLCachingDemo {
+
+  private static final EnvLoader env = new EnvLoader();
+  private static final Logger LOGGER = Logger.getLogger(SQLCachingDemo.class.getName());
+
+  private static final String DB_CONNECTION_STRING = env.get("DB_CONNECTION_STRING");
+  private static final String USERNAME = env.get("DB_USERNAME");
+  private static final String PASSWORD = env.get("DB_PASSWORD");
+
+  // No Auth endpoints
+  private static final String NO_AUTH_RW = env.get("NO_AUTH_RW_ADDR");
+  private static final String NO_AUTH_RO = env.get("NO_AUTH_RO_ADDR");
+
+  // Traditional Auth endpoints and credentials
+  private static final String TRAD_AUTH_RW = env.get("TRAD_AUTH_RW_ADDR");
+  private static final String TRAD_AUTH_RO = env.get("TRAD_AUTH_RO_ADDR");
+  private static final String TRAD_CACHE_USERNAME = env.get("TRAD_CACHE_USERNAME");
+  private static final String CACHE_PASSWORD = env.get("CACHE_PASSWORD");
+
+  // IAM Auth endpoints and credentials
+  private static final String IAM_AUTH_RW = env.get("IAM_AUTH_RW_ADDR");
+  private static final String IAM_AUTH_RO = env.get("IAM_AUTH_RO_ADDR");
+  private static final String CACHE_USERNAME = env.get("CACHE_USERNAME");
+  private static final String CACHE_NAME = env.get("CACHE_NAME");
+  private static final String CACHE_IAM_REGION = env.get("CACHE_IAM_REGION");
+
+  public static void main(String[] args) throws SQLException, InterruptedException {
+    if (args.length == 0) {
+      System.out.println("Usage: java SQLCachingDemo <demo_type>");
+      System.out.println("Demo types: noauth | traditional | iam");
+      return;
+    }
+
+    String demoType = args[0].toLowerCase();
+    System.out.println("=== AWS JDBC Driver Cache Authentication Demo ===\n");
+
+    switch (demoType) {
+      case "noauth":
+        System.out.println("DEMO: No Authentication Cache");
+        runCacheDemo(createNoAuthProperties(), "NO_AUTH", 60);
+        break;
+      case "traditional":
+        System.out.println("DEMO: Traditional Username/Password Authentication");
+        runCacheDemo(createTraditionalAuthProperties(), "TRADITIONAL_AUTH", 60);
+        break;
+      case "iam":
+        System.out.println("DEMO: IAM Authentication");
+        runCacheDemo(createIamAuthProperties(), "IAM_AUTH", 60);
+        break;
+      default:
+        System.err.println("Invalid demo type. Use: noauth | traditional | iam");
+    }
+  }
+
+  private static Properties createDefaultProperties(String rw, String ro) {
+    Properties props = new Properties();
+    props.setProperty("user", USERNAME);
+    props.setProperty("password", PASSWORD);
+    props.setProperty("wrapperPlugins", "dataRemoteCache");
+    props.setProperty("cacheEndpointAddrRw", rw);
+    props.setProperty("cacheEndpointAddrRo", ro);
+    props.setProperty("cacheUseSSL", "true");
+    return props;
+  }
+
+  private static Properties createNoAuthProperties() {
+    return createDefaultProperties(NO_AUTH_RW, NO_AUTH_RO);
+  }
+
+  private static Properties createTraditionalAuthProperties() {
+    Properties props = createDefaultProperties(TRAD_AUTH_RW, TRAD_AUTH_RO);
+    props.setProperty("cacheUseSSL", "true");
+    props.setProperty("cacheUsername", TRAD_CACHE_USERNAME);
+    props.setProperty("cachePassword", CACHE_PASSWORD);
+    return props;
+  }
+
+  private static Properties createIamAuthProperties() {
+    Properties props = createDefaultProperties(IAM_AUTH_RW, IAM_AUTH_RO);
+    props.setProperty("cacheUsername", CACHE_USERNAME);
+    props.setProperty("cacheName", CACHE_NAME);
+    props.setProperty("cacheIamRegion", CACHE_IAM_REGION);
+    return props;
+  }
+
+  private static void runCacheDemo(Properties properties, String authType, int durationSeconds) {
+    System.out.println("   Starting " + authType + " demo for " + durationSeconds + " seconds...");
+
+    String[] queries = {
+        "/*+ CACHE_PARAM(ttl=5s) */ SELECT 'Cache Test 1' as test_data, NOW() as timestamp",
+        "/*+ CACHE_PARAM(ttl=5s) */ SELECT 'Cache Test 2' as test_data, CURRENT_TIMESTAMP as timestamp",
+        "/*+ CACHE_PARAM(ttl=5s) */ SELECT 'Cache Test 3' as test_data, 'Demo Data' as info",
+        "/*+ CACHE_PARAM(ttl=5s) */ SELECT * from cinemas"
+    };
+
+    long endTime = System.currentTimeMillis() + (durationSeconds * 1000L);
+    int operationCount = 0;
+
+    try (Connection conn = DriverManager.getConnection(DB_CONNECTION_STRING, properties);
+         Statement stmt = conn.createStatement()) {
+
+      while (System.currentTimeMillis() < endTime) {
+        String query = queries[operationCount % queries.length];
+
+        try {
+          ResultSet rs = stmt.executeQuery(query);
+          if (rs.next()) {
+            System.out.println("   [" + authType + "] Operation #" + (++operationCount) +
+                " - Query executed successfully: " + rs.getString(1));
+          }
+          rs.close();
+
+          // Sleep for 1 seconds between operations for easy monitoring
+          Thread.sleep(1000);
+
+        } catch (SQLException e) {
+          System.err.println("   [" + authType + "] SQL Error: " + e.getMessage());
+          break;
+        }
+      }
+
+    } catch (SQLException e) {
+      System.err.println("   [" + authType + "] Connection Error: " + e.getMessage());
+    } catch (InterruptedException e) {
+      System.err.println("   [" + authType + "] Thread interrupted: " + e.getMessage());
+    }
+
+    System.out.println("   " + authType + " demo completed. Total operations: " + operationCount);
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CacheConnection.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CacheConnection.java
@@ -32,6 +32,7 @@ import software.amazon.awssdk.regions.Region;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -106,7 +107,13 @@ public class CacheConnection {
       new AwsWrapperProperty(
           "cacheName",
           null,
-          "Explicit cache name for ElastiCache IAM authentication. ");
+          "Explicit cache name for ElastiCache IAM authentication.");
+
+  protected static final AwsWrapperProperty CACHE_FAIL_ON_ERROR =
+      new AwsWrapperProperty(
+          "cacheFailOnError",
+          "false",
+          "Whether to throw SQLException on cache failures.");
 
   protected static final AwsWrapperProperty CACHE_CONNECTION_TIMEOUT =
       new AwsWrapperProperty(
@@ -125,12 +132,13 @@ public class CacheConnection {
   private static volatile GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> writeConnectionPool;
   private static final GenericObjectPoolConfig<StatefulRedisConnection<byte[], byte[]>> poolConfig = createPoolConfig();
 
-  private final boolean useSSL;
+  private final boolean cacheUseSSL;
   private final boolean iamAuthEnabled;
   private final String cacheIamRegion;
   private final String cacheUsername;
   private final String cacheName;
   private final String cachePassword;
+  private final Boolean cacheFailOnError;
   private final Duration cacheConnectionTimeout;
   private final int cacheConnectionPoolSize;
   private final Properties awsProfileProperties;
@@ -143,7 +151,7 @@ public class CacheConnection {
   public CacheConnection(final Properties properties) {
     this.cacheRwServerAddr = CACHE_RW_ENDPOINT_ADDR.getString(properties);
     this.cacheRoServerAddr = CACHE_RO_ENDPOINT_ADDR.getString(properties);
-    this.useSSL = Boolean.parseBoolean(CACHE_USE_SSL.getString(properties));
+    this.cacheUseSSL = Boolean.parseBoolean(CACHE_USE_SSL.getString(properties));
     this.cacheName = CACHE_NAME.getString(properties);
     this.cacheIamRegion = CACHE_IAM_REGION.getString(properties);
     this.cacheUsername = CACHE_USERNAME.getString(properties);
@@ -191,6 +199,7 @@ public class CacheConnection {
     } else {
       this.credentialsProvider = null;
     }
+    this.cacheFailOnError = Boolean.parseBoolean(CACHE_FAIL_ON_ERROR.getString(properties));
   }
 
   /* Here we check if we need to initialise connection pool for read or write to cache.
@@ -288,7 +297,7 @@ public class CacheConnection {
     return msgHashDigest.digest();
   }
 
-  public byte[] readFromCache(String key) {
+  public byte[] readFromCache(String key) throws SQLException {
     boolean isBroken = false;
     StatefulRedisConnection<byte[], byte[]> conn = null;
     // get a connection from the read connection pool
@@ -299,6 +308,9 @@ public class CacheConnection {
     } catch (Exception e) {
       if (conn != null) {
         isBroken = true;
+      }
+      if (cacheFailOnError) {
+        throw new SQLException("Cache read operation failed", e);
       }
       LOGGER.warning("Failed to read result from cache. Treating it as a cache miss: " + e.getMessage());
       return null;
@@ -335,26 +347,38 @@ public class CacheConnection {
     }
   }
 
-  public void writeToCache(String key, byte[] value, int expiry) {
+  public void writeToCache(String key, byte[] value, int expiry) throws SQLException {
     StatefulRedisConnection<byte[], byte[]> conn = null;
+    boolean shouldReturnConnection = true;
     try {
       initializeCacheConnectionIfNeeded(false);
       // get a connection from the write connection pool
       conn = writeConnectionPool.borrowObject();
-      // Write to the cache is async.
-      RedisAsyncCommands<byte[], byte[]> asyncCommands = conn.async();
       byte[] keyHash = computeHashDigest(key.getBytes(StandardCharsets.UTF_8));
-      StatefulRedisConnection<byte[], byte[]> finalConn = conn;
-      asyncCommands.set(keyHash, value, SetArgs.Builder.ex(expiry))
-          .whenComplete((result, exception) -> handleCompletedCacheWrite(finalConn, exception));
+
+      if (cacheFailOnError) {
+        conn.sync().set(keyHash, value, SetArgs.Builder.ex(expiry));
+      } else {
+        // Write to the cache is async.
+        RedisAsyncCommands<byte[], byte[]> asyncCommands = conn.async();
+        StatefulRedisConnection<byte[], byte[]> finalConn = conn;
+        asyncCommands.set(keyHash, value, SetArgs.Builder.ex(expiry))
+            .whenComplete((result, exception) -> handleCompletedCacheWrite(finalConn, exception));
+        shouldReturnConnection = false; // Async callback will handle return
+      }
     } catch (Exception e) {
+      if (cacheFailOnError) {
+        throw new SQLException("Cache write operation failed", e);
+      }
       // Failed to trigger the async write to the cache, return the cache connection to the pool as broken
       LOGGER.warning("Unable to start writing to cache: " + e.getMessage());
-      if (conn != null && writeConnectionPool != null) {
+    } finally {
+      if (conn != null && writeConnectionPool != null && shouldReturnConnection) {
+        // Only return connection immediately for synchronous operations or async operation failed to start
         try {
           returnConnectionBackToPool(conn, true, false);
         } catch (Exception ex) {
-          LOGGER.warning("Error closing write connection: " + ex.getMessage());
+          LOGGER.warning("Error returning write connection: " + ex.getMessage());
         }
       }
     }
@@ -388,7 +412,7 @@ public class CacheConnection {
   protected RedisURI buildRedisURI(String hostname, int port) {
     RedisURI.Builder uriBuilder = RedisURI.Builder.redis(hostname)
         .withPort(port)
-        .withSsl(useSSL)
+        .withSsl(cacheUseSSL)
         .withVerifyPeer(false)
         .withLibraryName("aws-sql-jdbc-lettuce")
         .withTimeout(cacheConnectionTimeout);
@@ -423,5 +447,9 @@ public class CacheConnection {
 
   private String[] getHostnameAndPort(String serverAddr) {
     return serverAddr.split(":");
+  }
+
+  public boolean shouldFailOnError() {
+    return cacheFailOnError;
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/DataRemoteCachePlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/DataRemoteCachePlugin.java
@@ -106,7 +106,7 @@ public class DataRemoteCachePlugin extends AbstractConnectionPlugin {
     return subscribedMethods;
   }
 
-  private String getCacheQueryKey(String query) {
+  private String getCacheQueryKey(String query) throws SQLException {
     // Check some basic session states. The important ones for caching include (but not limited to):
     //  schema name, username which can affect the query result from the DB in addition to the query string
     try {
@@ -140,12 +140,15 @@ public class DataRemoteCachePlugin extends AbstractConnectionPlugin {
       String[] words = {catalog, schema, dbUserName, query};
       return String.join("_", words);
     } catch (SQLException e) {
+      if (cacheConnection.shouldFailOnError()) {
+        throw new SQLException("Cache get query key failed", e);
+      }
       LOGGER.warning("Error getting session state: " + e.getMessage());
       return null;
     }
   }
 
-  private ResultSet fetchResultSetFromCache(String queryStr) {
+  private ResultSet fetchResultSetFromCache(String queryStr) throws SQLException {
     if (cacheConnection == null) return null;
 
     String cacheQueryKey = getCacheQueryKey(queryStr);
@@ -156,6 +159,9 @@ public class DataRemoteCachePlugin extends AbstractConnectionPlugin {
     try {
       return CachedResultSet.deserializeFromByteArray(cachedResult);
     } catch (Exception e) {
+      if (cacheConnection.shouldFailOnError()) { // Need to expose this setting
+        throw new SQLException("Cache deserialization failed", e);
+      }
       LOGGER.warning("Error de-serializing cached result: " + e.getMessage());
       return null; // Treat this as a cache miss
     }
@@ -168,11 +174,36 @@ public class DataRemoteCachePlugin extends AbstractConnectionPlugin {
    */
   private ResultSet cacheResultSet(String queryStr, ResultSet rs, int expiry) throws SQLException {
     // Write the resultSet into the cache as a single key
-    String cacheQueryKey = getCacheQueryKey(queryStr);
+    String cacheQueryKey;
+    try {
+      cacheQueryKey = getCacheQueryKey(queryStr);
+    } catch (SQLException e) {
+      // getCacheQueryKey already handles failOnError logic
+      throw e;
+    }
+
     if (cacheQueryKey == null) return rs; // Treat this condition as un-cacheable
-    CachedResultSet crs = new CachedResultSet(rs);
-    byte[] jsonString = crs.serializeIntoByteArray();
-    cacheConnection.writeToCache(cacheQueryKey, jsonString, expiry);
+
+    CachedResultSet crs;
+    byte[] jsonString;
+    try {
+      crs = new CachedResultSet(rs);
+      jsonString = crs.serializeIntoByteArray();
+    } catch (Exception e) {
+      if (cacheConnection.shouldFailOnError()) {
+        throw new SQLException("Cache serialization failed", e);
+      }
+      LOGGER.warning("Error serializing result for cache: " + e.getMessage());
+      return rs;
+    }
+
+    try {
+      cacheConnection.writeToCache(cacheQueryKey, jsonString, expiry);
+    } catch (SQLException e) {
+      // writeToCache already handles failOnError logic
+      throw e;
+    }
+
     crs.beforeFirst();
     return crs;
   }
@@ -285,7 +316,7 @@ public class DataRemoteCachePlugin extends AbstractConnectionPlugin {
       cacheContext = telemetryFactory.openTelemetryContext(
           TELEMETRY_CACHE_LOOKUP, TelemetryTraceLevel.TOP_LEVEL);
       Exception cacheException = null;
-      try{
+      try {
         result = fetchResultSetFromCache(mainQuery);
         if (result == null) {
           // Cache miss. Need to fetch result from the database
@@ -304,6 +335,14 @@ public class DataRemoteCachePlugin extends AbstractConnectionPlugin {
           }
           return resultClass.cast(result);
         }
+      } catch (SQLException cacheEx) {
+        // Cache failure in ERROR mode -- propagate the exception
+        if (cacheContext != null) {
+          cacheContext.setSuccess(false);
+          cacheContext.setException(cacheEx);
+          cacheContext.closeContext();
+        }
+        throw WrapperUtils.wrapExceptionIfNeeded(exceptionClass, cacheEx);
       } finally {
         if (cacheContext != null) {
           if (cacheException != null) {


### PR DESCRIPTION
### Summary

Add configurable cache failure handling with cacheFailOnError parameter

### Description

This PR introduces a new configuration parameter `cacheFailOnError` to control behavior when cache operations fail, addressing the need to prevent cache failures from overloading the backing database.

Key Changes:

Cache Failure Mode Configuration:
• Added `cacheFailOnError` property (default: false)
• **FALLBACK mode** (false): Cache failures fall back to database queries (existing behavior)
• **ERROR mode** (true): Cache failures throw `SQLException`, preventing database fallback

Comprehensive Failure Handling:
• **Cache connection/network failures**: server unavailable, invalid endpoints
• **Authentication failures**: IAM token issues, invalid credentials  
• **Serialization/deserialization failures**: Corrupted cache data, JSON parsing errors
• **Redis command execution errors**: Memory limits, no key evictions
• **Cache key generation failures**: Database metadata access issues

Implementation Details:
• Modified `CacheConnection.java`: Added failure mode logic to `readFromCache()` and `writeToCache()`
• Updated `DataRemoteCachePlugin.java`: Enhanced error handling in `fetchResultSetFromCache()`, `getCacheQueryKey()`, and `cacheResultSet()`
• Added `shouldFailOnError()` method to expose configuration setting
• Separated serialization vs write failure error messages for better debugging

Example Program Improvements:
• Renamed `USE_SSL` to `CACHE_USE_SSL` in `DatabaseConnectionWithCacheExample.java` for clarity
• Reorganized cache-related configuration variables for better readability

Benefits:
• Prevents silent performance degradation during cache outages
• Allows applications to fail fast on cache issues
• Maintains backward compatibility (default behavior unchanged)
• Provides clear error messages for different failure types

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.