### PR TITLE
Caching: Allow user to configure cache connection timeout and connect…

### DIFF
--- a/examples/AWSDriverExample/src/main/java/software/amazon/DatabaseConnectionWithCacheExample.java
+++ b/examples/AWSDriverExample/src/main/java/software/amazon/DatabaseConnectionWithCacheExample.java
@@ -17,13 +17,15 @@ public class DatabaseConnectionWithCacheExample {
   // Both IAM and traditional auth uses the same CACHE_USERNAME
   private static final String CACHE_USERNAME = env.get("CACHE_USERNAME"); // e.g., "iam-user-01" / "username"
   private static final String CACHE_IAM_REGION = env.get("CACHE_IAM_REGION"); // e.g., "us-west-2"
+  private static final String CACHE_USE_SSL = env.get("CACHE_USE_SSL");
   // If the cache server is authenticated with traditional username password
   // private static final String CACHE_PASSWORD = env.get("CACHE_PASSWORD");
   private static final String USERNAME = env.get("DB_USERNAME");
   private static final String PASSWORD = env.get("DB_PASSWORD");
-  private static final String USE_SSL = env.get("USE_SSL");
   private static final int THREAD_COUNT = 8; //Use 8 Threads
   private static final long TEST_DURATION_MS = 16000; //Test duration for 16 seconds
+  private static final String CACHE_CONNECTION_TIMEOUT = env.get("CACHE_CONNECTION_TIMEOUT"); //Set connection timeout in milliseconds
+  private static final String CACHE_CONNECTION_POOL_SIZE = env.get("CACHE_CONNECTION_POOL_SIZE"); //Set connection pool size
 
   public static void main(String[] args) throws SQLException {
     final Properties properties = new Properties();
@@ -43,8 +45,10 @@ public class DatabaseConnectionWithCacheExample {
     properties.setProperty("cacheIamRegion", CACHE_IAM_REGION);
     // If the cache server is authenticated with traditional username password
     // properties.setProperty("cachePassword", PASSWORD);
-    properties.setProperty("cacheUseSSL", USE_SSL); // "true" or "false"
+    properties.setProperty("cacheUseSSL", CACHE_USE_SSL); // "true" or "false"
     properties.setProperty("wrapperLogUnclosedConnections", "true");
+    properties.setProperty("cacheConnectionTimeout", CACHE_CONNECTION_TIMEOUT);
+    properties.setProperty("cacheConnectionPoolSize", CACHE_CONNECTION_POOL_SIZE);
     String queryStr = "/*+ CACHE_PARAM(ttl=300s) */ select * from cinemas";
 
     // Create threads for concurrent connection testing


### PR DESCRIPTION
### Summary

Allow User to configure Cache connection timeout and Cache connection pool size. 

### Description

This PR includes in introducing two new config parameters (`cacheConnectionTimeOut`,  `cacheConnectionPoolSize`) for the user to change the default Cache connection timeout and the Cache connection pool size. 

By default, client connection timeout is set to 60 seconds which is too long for the request to wait for cache. The default cache connection time out is now set to 2 seconds. User can configure this in milliseconds based on their requirement.

The connection pool size is smaller than the number of concurrent database connections, leading to client borrow timeouts. i.e. `WARNING: Failed to read result from cache. Treating it as a cache miss: Timeout waiting for idle object, borrowMaxWaitDuration=PT0.1S`

Default pool size is currently set to 20 and the max pool size is set to 200. User can change the connection pool size based on their requirement. 

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.