### PR TITLE
Updated `CacheResultSet.convertToTime()` to handle offset with cal

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CachedResultSet.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CachedResultSet.java
@@ -377,8 +377,18 @@ public class CachedResultSet implements ResultSet {
       return Time.valueOf(targetZonedDateTime.toLocalTime());
     }
     if (timeObj instanceof OffsetTime) {
-      OffsetTime localTime = ((OffsetTime)timeObj).withOffsetSameInstant(OffsetDateTime.now().getOffset());
-      return Time.valueOf(localTime.toLocalTime());
+      OffsetTime offsetTime = (OffsetTime) timeObj;
+      if (cal == null) {
+        // Convert to default timezone using ZonedDateTime conversion
+        ZonedDateTime zonedDateTime = offsetTime.atDate(LocalDate.now())
+            .atZoneSameInstant(defaultTimeZoneId);
+        return Time.valueOf(zonedDateTime.toLocalTime());
+      } else {
+        // Convert to specified calendar timezone
+        ZonedDateTime zonedDateTime = offsetTime.atDate(LocalDate.now())
+            .atZoneSameInstant(cal.getTimeZone().toZoneId());
+        return Time.valueOf(zonedDateTime.toLocalTime());
+      }
     }
     if (timeObj instanceof Timestamp) {
       Timestamp timestamp = (Timestamp) timeObj;

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CachedResultSetTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CachedResultSetTest.java
@@ -398,8 +398,15 @@ public class CachedResultSetTest {
     assertEquals(Time.valueOf("07:20:30"), cachedRs.getTime(1, estCal));
     // Time from OffsetTime
     assertTrue(cachedRs.next());
-    assertEquals(Time.valueOf("05:15:30"), cachedRs.getTime(1));
-    assertEquals(Time.valueOf("05:15:30"), cachedRs.getTime(1, estCal));
+    // OffsetTime.of(12, 15, 30, 0, ZoneOffset.UTC) converted to default timezone
+    OffsetTime offsetTimeUtc = OffsetTime.of(12, 15, 30, 0, ZoneOffset.UTC);
+    ZonedDateTime expectedDefaultTz = offsetTimeUtc.atDate(LocalDate.now())
+        .atZoneSameInstant(defaultTimeZone.toZoneId());
+    assertEquals(Time.valueOf(expectedDefaultTz.toLocalTime()), cachedRs.getTime(1));
+    // OffsetTime converted to EST timezone
+    ZonedDateTime expectedEstTz = offsetTimeUtc.atDate(LocalDate.now())
+        .atZoneSameInstant(estCal.getTimeZone().toZoneId());
+    assertEquals(Time.valueOf(expectedEstTz.toLocalTime()), cachedRs.getTime(1, estCal));
     // Time from Timestamp
     assertTrue(cachedRs.next());
     Timestamp timestampOne = new Timestamp(1755621000000L);


### PR DESCRIPTION
### Summary

Updated `CacheResultSet.convertToTime()` to also handle offset time with calendar. Fixed corresponding test cases to be DST independent. 
