### PR TITLE
Implement cache failure mode handling with health monitoring

### DIFF
--- a/examples/AWSDriverExample/src/main/java/software/amazon/DatabaseConnectionWithCacheExample.java
+++ b/examples/AWSDriverExample/src/main/java/software/amazon/DatabaseConnectionWithCacheExample.java
@@ -26,6 +26,10 @@ public class DatabaseConnectionWithCacheExample {
   private static final long TEST_DURATION_MS = 16000; //Test duration for 16 seconds
   private static final String CACHE_CONNECTION_TIMEOUT = env.get("CACHE_CONNECTION_TIMEOUT"); //Set connection timeout in milliseconds
   private static final String CACHE_CONNECTION_POOL_SIZE = env.get("CACHE_CONNECTION_POOL_SIZE"); //Set connection pool size
+  // Failure handling configurations
+  private static final String FAIL_WHEN_CACHE_DOWN = env.get("FAIL_WHEN_CACHE_DOWN");
+  private static final String CACHE_IN_FLIGHT_WRITE_SIZE_LIMIT = env.get("CACHE_IN_FLIGHT_WRITE_SIZE_LIMIT");
+  private static final String CACHE_HEALTH_CHECK_IN_HEALTHY_STATE = env.get("CACHE_HEALTH_CHECK_IN_HEALTHY_STATE");
 
   public static void main(String[] args) throws SQLException {
     final Properties properties = new Properties();
@@ -44,11 +48,15 @@ public class DatabaseConnectionWithCacheExample {
     properties.setProperty("cacheUsername", CACHE_USERNAME);
     properties.setProperty("cacheIamRegion", CACHE_IAM_REGION);
     // If the cache server is authenticated with traditional username password
-    // properties.setProperty("cachePassword", PASSWORD);
+    // properties.setProperty("cachePassword", CACHE_PASSWORD);
     properties.setProperty("cacheUseSSL", CACHE_USE_SSL); // "true" or "false"
     properties.setProperty("wrapperLogUnclosedConnections", "true");
     properties.setProperty("cacheConnectionTimeout", CACHE_CONNECTION_TIMEOUT);
     properties.setProperty("cacheConnectionPoolSize", CACHE_CONNECTION_POOL_SIZE);
+    properties.setProperty("failWhenCacheDown", FAIL_WHEN_CACHE_DOWN);
+    properties.setProperty("cacheInFlightWriteSizeLimitBytes", CACHE_IN_FLIGHT_WRITE_SIZE_LIMIT);
+    properties.setProperty("cacheHealthCheckInHealthyState", CACHE_HEALTH_CHECK_IN_HEALTHY_STATE);
+
     String queryStr = "/*+ CACHE_PARAM(ttl=300s) */ select * from cinemas";
 
     // Create threads for concurrent connection testing

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CacheMonitor.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CacheMonitor.java
@@ -1,0 +1,527 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.cache;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Logger;
+import io.lettuce.core.RedisCommandExecutionException;
+import io.lettuce.core.RedisConnectionException;
+import io.lettuce.core.RedisException;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import java.time.Duration;
+import software.amazon.jdbc.AwsWrapperProperty;
+import software.amazon.jdbc.util.telemetry.TelemetryCounter;
+import software.amazon.jdbc.util.telemetry.TelemetryFactory;
+import software.amazon.jdbc.util.telemetry.TelemetryGauge;
+
+/**
+ * This class uses a background thread to monitor cache cluster health and manage state transitions.
+ *
+ * Implements a three-state machine (HEALTHY → SUSPECT → DEGRADED) with proactive health checks
+ * that only run when clusters are in SUSPECT or DEGRADED states.
+ */
+public class CacheMonitor implements Runnable {
+
+  private static final Logger LOGGER = Logger.getLogger(CacheMonitor.class.getName());
+
+  // Singleton instance
+  private static volatile CacheMonitor instance;
+  private static final Object INSTANCE_LOCK = new Object();
+
+  private static final long THREAD_SLEEP_WHEN_INACTIVE_MILLIS = 100;
+  private static final int CACHE_HEALTH_CHECK_INTERVAL = 5;
+  private static final int CACHE_CONSECUTIVE_SUCCESS_THRESHOLD = 3;
+  private static final int CACHE_CONSECUTIVE_FAILURE_THRESHOLD = 3;
+
+  // Track if monitor thread has been started
+  private static volatile boolean monitorThreadStarted = false;
+  private static final Object THREAD_START_LOCK = new Object();
+
+  // Configuration properties
+  public static final AwsWrapperProperty CACHE_IN_FLIGHT_WRITE_SIZE_LIMIT =
+      new AwsWrapperProperty(
+          "cacheInFlightWriteSizeLimitBytes",
+          String.valueOf(50 * 1024 * 1024), // 50 MB
+          "Maximum in-flight write size in bytes before triggering degraded mode.");
+
+  public static final AwsWrapperProperty CACHE_HEALTH_CHECK_IN_HEALTHY_STATE =
+      new AwsWrapperProperty(
+          "cacheHealthCheckInHealthyState",
+          "false",
+          "Whether to run health checks (pings) in healthy state.");
+
+  private static final Map<String, ClusterHealthState> clusterStates = new ConcurrentHashMap<>();
+  private final long inFlightWriteSizeLimitBytes;
+  private final boolean healthCheckInHealthyState;
+  private volatile boolean stopped = false;
+
+  // Telemetry
+  private final TelemetryFactory telemetryFactory;
+  private static TelemetryCounter stateTransitionCounter;
+  private static TelemetryCounter healthCheckSuccessCounter;
+  private static TelemetryCounter healthCheckFailureCounter;
+  private static TelemetryCounter errorCounter;
+  private static TelemetryGauge consecutiveSuccessGauge;
+  private static TelemetryGauge consecutiveFailureGauge;
+
+  /**
+   * Enum representing the health state of a cache cluster or endpoint.
+   */
+  protected enum HealthState {
+    HEALTHY,
+    SUSPECT,
+    DEGRADED
+  }
+
+  /* Categories of cache errors for classification and handling */
+  protected enum ErrorCategory {
+    CONNECTION,  // Network issues, timeouts, connection refused
+    COMMAND,     // Invalid syntax, wrong arguments
+    DATA,        // Serialization failures, data corruption
+    RESOURCE     // Memory limits, cluster issues
+  }
+
+  /**
+   * Represents a cache cluster with RW and optional RO endpoints.
+   * This is the single source of truth for cluster health state.
+   */
+  static class ClusterHealthState {
+    final String rwEndpoint;
+    final String roEndpoint;  // Null if no separate RO endpoint
+
+    // Separate health states for RW and RO endpoints
+    volatile HealthState rwHealthState;
+    volatile HealthState roHealthState;
+
+    // Consecutive result tracking for RW endpoint (only accessed by CacheMonitor thread)
+    int consecutiveRwSuccesses;
+    int consecutiveRwFailures;
+
+    // Consecutive result tracking for RO endpoint (only accessed by CacheMonitor thread)
+    int consecutiveRoSuccesses;
+    int consecutiveRoFailures;
+
+    // Memory pressure tracking (only for RW endpoint, accessed by multiple threads)
+    final AtomicLong inFlightWriteSizeBytes;
+
+    // Ping connections - one for RW, one for RO if different
+    volatile CachePingConnection rwPingConnection;
+    volatile CachePingConnection roPingConnection;  // Null if no separate RO endpoint
+
+    // Configuration for creating ping connections
+    final boolean useSSL;
+    final Duration cacheConnectionTimeout;
+    final boolean iamAuthEnabled;
+    final AwsCredentialsProvider credentialsProvider;
+    final String cacheIamRegion;
+    final String cacheName;
+    final String cacheUsername;
+    final String cachePassword;
+
+    ClusterHealthState(String rwEndpoint, String roEndpoint, boolean useSSL, Duration cacheConnectionTimeout,
+        boolean iamAuthEnabled, AwsCredentialsProvider credentialsProvider, String cacheIamRegion,
+        String cacheName, String cacheUsername, String cachePassword) {
+      this.rwEndpoint = rwEndpoint;
+      // If roEndpoint equals rwEndpoint, treat it as null
+      this.roEndpoint = (roEndpoint != null && roEndpoint.equals(rwEndpoint)) ? null : roEndpoint;
+      this.useSSL = useSSL;
+      this.cacheConnectionTimeout = cacheConnectionTimeout;
+      this.iamAuthEnabled = iamAuthEnabled;
+      this.credentialsProvider = credentialsProvider;
+      this.cacheIamRegion = cacheIamRegion;
+      this.cacheName = cacheName;
+      this.cacheUsername = cacheUsername;
+      this.cachePassword = cachePassword;
+
+      // Initialize health states
+      this.rwHealthState = HealthState.HEALTHY;
+      this.roHealthState = HealthState.HEALTHY;
+
+      // Initialize counters
+      this.consecutiveRwSuccesses = 0;
+      this.consecutiveRwFailures = 0;
+      this.consecutiveRoSuccesses = 0;
+      this.consecutiveRoFailures = 0;
+      this.inFlightWriteSizeBytes = new AtomicLong(0);
+    }
+
+    String getClusterKey() {
+      return generateClusterKey(rwEndpoint, roEndpoint);
+    }
+
+    static String generateClusterKey(String rwEndpoint, String roEndpoint) {
+      String normalizedRo = (roEndpoint != null && roEndpoint.equals(rwEndpoint)) ? null : roEndpoint;
+      return normalizedRo == null ? rwEndpoint + "|" : rwEndpoint + "|" + normalizedRo;
+    }
+
+    /**
+     * Transition health state for a specific endpoint.
+     */
+    void transitionToState(HealthState newState, boolean isRw, String triggerReason, TelemetryCounter counter) {
+      String endpoint = isRw ? rwEndpoint : roEndpoint;
+      HealthState oldState = isRw ? rwHealthState : roHealthState;
+
+      // Update state
+      if (isRw) {
+        rwHealthState = newState;
+        consecutiveRwSuccesses = 0;
+        consecutiveRwFailures = 0;
+      } else {
+        roHealthState = newState;
+        consecutiveRoSuccesses = 0;
+        consecutiveRoFailures = 0;
+      }
+
+      // Emit telemetry
+      if (counter != null) {
+        counter.inc();
+      }
+
+      // Log state transition
+      if (!triggerReason.startsWith("recoverable_error_")) {
+        String logMessage = String.format(
+            "[%s to %s] Cache endpoint %s (%s) health state transitioned (trigger: %s)",
+            oldState, newState, endpoint, isRw ? "RW" : "RO", triggerReason);
+
+        LOGGER.fine(logMessage);
+      }
+    }
+
+    /**
+     * Get the overall cluster health state based on both endpoints.
+     */
+    HealthState getClusterHealthState() {
+      // If no separate RO endpoint, return RW state
+      if (roEndpoint == null) {
+        return rwHealthState;
+      }
+
+      // Compute cluster state based on both endpoints
+      if (rwHealthState == HealthState.HEALTHY && roHealthState == HealthState.HEALTHY) {
+        return HealthState.HEALTHY;
+      } else if (rwHealthState == HealthState.DEGRADED || roHealthState == HealthState.DEGRADED) {
+        return HealthState.DEGRADED;
+      } else {
+        return HealthState.SUSPECT; // Mixed states
+      }
+    }
+  }
+
+  protected static void registerCluster(long inFlightWriteSizeLimitBytes, boolean healthCheckInHealthyState,
+                                        TelemetryFactory telemetryFactory,
+                                        String rwEndpoint, String roEndpoint, boolean useSSL, Duration cacheConnectionTimeout,
+                                        boolean iamAuthEnabled, AwsCredentialsProvider credentialsProvider, String cacheIamRegion,
+                                        String cacheName, String cacheUsername, String cachePassword, boolean createPingConnection,
+                                        boolean startMonitorThread) {
+    if (getCluster(rwEndpoint, roEndpoint) != null) {
+      return; // if cluster has already been registered
+    }
+    if (instance == null) {
+      synchronized (INSTANCE_LOCK) {
+        if (instance == null) {
+          instance = new CacheMonitor(inFlightWriteSizeLimitBytes, healthCheckInHealthyState, telemetryFactory);
+          LOGGER.info("Created CacheMonitor instance " + (telemetryFactory != null ? "with" : "without") + " telemetry");
+        }
+      }
+    }
+    ClusterHealthState clusterState = new ClusterHealthState(rwEndpoint, roEndpoint, useSSL, cacheConnectionTimeout,
+        iamAuthEnabled, credentialsProvider, cacheIamRegion, cacheName, cacheUsername, cachePassword);
+    ClusterHealthState existingCluster = clusterStates.putIfAbsent(clusterState.getClusterKey(), clusterState);
+    if (existingCluster == null) {
+      LOGGER.info(() -> "Registered cluster: " + clusterState.getClusterKey());
+      if (createPingConnection) {
+        instance.createInitialPingConnections(clusterState);
+      }
+    }
+    if (startMonitorThread) {
+      instance.startMonitoring();
+    }
+  }
+
+  protected static void registerCluster(long inFlightWriteSizeLimitBytes, boolean healthCheckInHealthyState,
+                                        TelemetryFactory telemetryFactory,
+                                        String rwEndpoint, String roEndpoint, boolean useSSL,
+                                        Duration cacheConnectionTimeout, boolean iamAuthEnabled,
+                                        AwsCredentialsProvider credentialsProvider, String cacheIamRegion,
+                                        String cacheName, String cacheUsername, String cachePassword) {
+    registerCluster(inFlightWriteSizeLimitBytes, healthCheckInHealthyState, telemetryFactory,
+            rwEndpoint, roEndpoint, useSSL,
+            cacheConnectionTimeout, iamAuthEnabled, credentialsProvider,
+            cacheIamRegion, cacheName, cacheUsername, cachePassword, true, true);
+  }
+
+  private CacheMonitor(long inFlightWriteSizeLimitBytes, boolean healthCheckInHealthyState, TelemetryFactory telemetryFactory) {
+    this.telemetryFactory = telemetryFactory;
+    this.inFlightWriteSizeLimitBytes = inFlightWriteSizeLimitBytes;
+    this.healthCheckInHealthyState = healthCheckInHealthyState;
+
+    if (telemetryFactory != null && stateTransitionCounter == null) {
+      stateTransitionCounter = telemetryFactory.createCounter("JdbcCacheStateTransitionCount");
+      healthCheckSuccessCounter = telemetryFactory.createCounter("JdbcCacheHealthCheckSuccessCount");
+      healthCheckFailureCounter = telemetryFactory.createCounter("JdbcCacheHealthCheckFailureCount");
+      errorCounter = telemetryFactory.createCounter("JdbcCacheErrorCount");
+
+      consecutiveSuccessGauge = telemetryFactory.createGauge("JdbcCacheConsecutiveSuccessCount",
+          () -> clusterStates.values().stream()
+              .mapToLong(c -> Math.max(c.consecutiveRwSuccesses, c.consecutiveRoSuccesses))
+              .max().orElse(0L));
+      consecutiveFailureGauge = telemetryFactory.createGauge("JdbcCacheConsecutiveFailureCount",
+          () -> clusterStates.values().stream()
+              .mapToLong(c -> Math.max(c.consecutiveRwFailures, c.consecutiveRoFailures))
+              .max().orElse(0L));
+    }
+  }
+
+  private void createInitialPingConnections(ClusterHealthState cluster) {
+    cluster.rwPingConnection = createPingConnection(cluster, false);
+    if (cluster.roEndpoint != null) {
+      cluster.roPingConnection = createPingConnection(cluster, true);
+    }
+  }
+
+  // Used for unit testing only
+  protected void setPingConnections(ClusterHealthState cluster,
+                                    CachePingConnection rwConnection,
+                                    CachePingConnection roConnection) {
+    cluster.rwPingConnection = rwConnection;
+    cluster.roPingConnection = roConnection;
+  }
+
+  private CachePingConnection createPingConnection(ClusterHealthState cluster, boolean isReadOnly) {
+    String[] hostPort = isReadOnly ? cluster.roEndpoint.split(":") : cluster.rwEndpoint.split(":");
+    return CacheConnection.createPingConnection(hostPort[0], Integer.parseInt(hostPort[1]),
+        isReadOnly, cluster.useSSL, cluster.cacheConnectionTimeout, cluster.iamAuthEnabled, cluster.credentialsProvider,
+        cluster.cacheIamRegion, cluster.cacheName, cluster.cacheUsername, cluster.cachePassword);
+  }
+
+  private static ClusterHealthState getCluster(String rwEndpoint, String roEndpoint) {
+    return clusterStates.get(ClusterHealthState.generateClusterKey(rwEndpoint, roEndpoint));
+  }
+
+  protected static HealthState getClusterState(String rwEndpoint, String roEndpoint) {
+    if (instance == null) {
+      return HealthState.HEALTHY;
+    }
+    ClusterHealthState cluster = getCluster(rwEndpoint, roEndpoint);
+    return cluster != null ? cluster.getClusterHealthState() : HealthState.HEALTHY;
+  }
+
+  private void startMonitoring() {
+    if (!monitorThreadStarted) {
+      synchronized (THREAD_START_LOCK) {
+        if (!monitorThreadStarted) {
+          Thread thread = new Thread(this, "CacheMonitorThread");
+          thread.setDaemon(true);
+          thread.start();
+          monitorThreadStarted = true;
+          LOGGER.info("Started CacheMonitor thread");
+        }
+      }
+    }
+  }
+
+  private static ErrorCategory classifyError(Throwable error) {
+    if (error instanceof RedisConnectionException) {
+      return ErrorCategory.CONNECTION;
+    }
+    if (error instanceof RedisCommandExecutionException) {
+      String msg = error.getMessage();
+      if (msg == null) return ErrorCategory.RESOURCE;
+      if (msg.contains("READONLY") || msg.contains("WRONGTYPE") || msg.contains("MOVED") || msg.contains("ASK")) {
+        return ErrorCategory.COMMAND;
+      }
+      if (msg.contains("OOM") || msg.contains("CLUSTERDOWN") || msg.contains("LOADING") ||
+          msg.contains("NOAUTH") || msg.contains("WRONGPASS")) {
+        return ErrorCategory.RESOURCE;
+      }
+      return ErrorCategory.COMMAND;
+    }
+    if (error instanceof RedisException) {
+      return ErrorCategory.CONNECTION;
+    }
+    return ErrorCategory.DATA;
+  }
+
+  private static boolean isRecoverableError(ErrorCategory category) {
+    return category != ErrorCategory.DATA;
+  }
+
+  protected static void reportError(String rwEndpoint, String roEndpoint, boolean isRw,
+      Throwable error, String operation) {
+    ClusterHealthState cluster = getCluster(rwEndpoint, roEndpoint);
+    if (cluster == null) {
+      LOGGER.warning("Error report for unregistered cluster: RW=" + rwEndpoint + ", RO=" + roEndpoint);
+      return;
+    }
+    ErrorCategory category = classifyError(error);
+    if (errorCounter != null) {
+      errorCounter.inc();
+    }
+    if (!isRecoverableError(category)) {
+      LOGGER.info(() -> "Non-recoverable error (" + category + ") for " +
+          (isRw ? rwEndpoint : roEndpoint) + ": " + error.getMessage());
+      return;
+    }
+    synchronized (cluster) {
+      HealthState currentState = isRw ? cluster.rwHealthState : cluster.roHealthState;
+      if (currentState == HealthState.HEALTHY) {
+        LOGGER.warning(String.format("[HEALTHY→SUSPECT] %s %s failed: %s - %s",
+            isRw ? rwEndpoint : roEndpoint, operation, category, error.getMessage()));
+        cluster.transitionToState(HealthState.SUSPECT, isRw,
+            "recoverable_error_" + category, stateTransitionCounter);
+      }
+    }
+  }
+
+  private void incrementInFlightSize(String rwEndpoint, String roEndpoint, long bytes) {
+    ClusterHealthState cluster = getCluster(rwEndpoint, roEndpoint);
+    if (cluster != null) {
+      long newSize = cluster.inFlightWriteSizeBytes.addAndGet(bytes);
+      synchronized (cluster) {
+        if (newSize > inFlightWriteSizeLimitBytes && cluster.rwHealthState != HealthState.DEGRADED) {
+          LOGGER.warning("In-flight write size limit exceeded: " + newSize);
+          cluster.transitionToState(HealthState.DEGRADED, true, "memory_pressure", stateTransitionCounter);
+        }
+      }
+    }
+  }
+
+  private void decrementInFlightSize(String rwEndpoint, String roEndpoint, long bytes) {
+    ClusterHealthState cluster = getCluster(rwEndpoint, roEndpoint);
+    if (cluster != null) {
+      cluster.inFlightWriteSizeBytes.updateAndGet(x -> Math.max(0, x - bytes));
+    }
+  }
+
+  protected static void incrementInFlightSizeStatic(String rwEndpoint, String roEndpoint, long bytes) {
+    if (instance != null) {
+      instance.incrementInFlightSize(rwEndpoint, roEndpoint, bytes);
+    }
+  }
+
+  protected static void decrementInFlightSizeStatic(String rwEndpoint, String roEndpoint, long bytes) {
+    if (instance != null) {
+      instance.decrementInFlightSize(rwEndpoint, roEndpoint, bytes);
+    }
+  }
+
+  @Override
+  public void run() {
+    LOGGER.info("Cache monitor thread started");
+    try {
+      this.stopped = false;
+      while (!stopped) {
+        try {
+          long start = System.currentTimeMillis();
+          boolean hasActiveMonitoring = false;
+          for (ClusterHealthState cluster : clusterStates.values()) {
+            if (cluster.getClusterHealthState() == HealthState.HEALTHY && !healthCheckInHealthyState) {
+              continue;
+            }
+            hasActiveMonitoring = true;
+            executePing(cluster, true);
+            if (cluster.roEndpoint != null) {
+              executePing(cluster, false);
+            }
+          }
+          long duration = System.currentTimeMillis() - start;
+          long target = hasActiveMonitoring ? TimeUnit.SECONDS.toMillis(CACHE_HEALTH_CHECK_INTERVAL)
+              : THREAD_SLEEP_WHEN_INACTIVE_MILLIS;
+          sleep(Math.max(0, target - duration));
+        } catch (InterruptedException e) {
+          throw e;
+        } catch (Exception e) {
+          LOGGER.warning("Cache monitoring exception: " + e.getMessage());
+        }
+      }
+    } catch (InterruptedException e) {
+      LOGGER.warning("Cache monitor interrupted");
+    } finally {
+      this.stopped = true;
+      LOGGER.info("Cache monitor stopped");
+    }
+  }
+
+  private void executePing(ClusterHealthState cluster, boolean isRw) {
+    String endpoint = isRw ? cluster.rwEndpoint : cluster.roEndpoint;
+    boolean success = ping(cluster, isRw);
+
+    HealthState currentState = isRw ? cluster.rwHealthState : cluster.roHealthState;
+    if (success) {
+      if (healthCheckSuccessCounter != null) {
+        healthCheckSuccessCounter.inc();
+      }
+      if (isRw) {
+        cluster.consecutiveRwSuccesses++;
+        cluster.consecutiveRwFailures = 0;
+      } else {
+        cluster.consecutiveRoSuccesses++;
+        cluster.consecutiveRoFailures = 0;
+      }
+      int consecutive_success = isRw ? cluster.consecutiveRwSuccesses : cluster.consecutiveRoSuccesses;
+      if (consecutive_success >= CACHE_CONSECUTIVE_SUCCESS_THRESHOLD) {
+        synchronized (cluster) {
+          if (currentState == HealthState.SUSPECT) {
+            cluster.transitionToState(HealthState.HEALTHY, isRw, "consecutive_successes", stateTransitionCounter);
+          } else if (currentState == HealthState.DEGRADED &&
+              cluster.inFlightWriteSizeBytes.get() < inFlightWriteSizeLimitBytes) {
+            cluster.transitionToState(HealthState.HEALTHY, isRw,
+                "consecutive_successes_and_memory_recovered", stateTransitionCounter);
+          }
+        }
+      }
+    } else {
+      LOGGER.warning(() -> "Ping failed for " + endpoint + " (" + (isRw ? "RW" : "RO") + ")");
+      if (healthCheckFailureCounter != null) healthCheckFailureCounter.inc();
+      if (isRw) {
+        cluster.consecutiveRwFailures++;
+        cluster.consecutiveRwSuccesses = 0;
+      } else {
+        cluster.consecutiveRoFailures++;
+        cluster.consecutiveRoSuccesses = 0;
+      }
+      int consecutive_failure = isRw ? cluster.consecutiveRwFailures : cluster.consecutiveRoFailures;
+      synchronized (cluster) {
+        if (currentState == HealthState.HEALTHY && consecutive_failure >= 1) {
+          cluster.transitionToState(HealthState.SUSPECT, isRw, "first_failure", stateTransitionCounter);
+        } else if (currentState == HealthState.SUSPECT && consecutive_failure >= CACHE_CONSECUTIVE_FAILURE_THRESHOLD) {
+          cluster.transitionToState(HealthState.DEGRADED, isRw, "consecutive_failures", stateTransitionCounter);
+        }
+      }
+    }
+  }
+
+  protected void sleep(long duration) throws InterruptedException {
+    TimeUnit.MILLISECONDS.sleep(duration);
+  }
+
+  private boolean ping(ClusterHealthState cluster, boolean isRw) {
+    CachePingConnection conn = isRw ? cluster.rwPingConnection : cluster.roPingConnection;
+    if (conn == null || !conn.isOpen()) {
+      return false;
+    }
+    try {
+      return conn.ping();
+    } catch (Exception e) {
+      LOGGER.warning("[ping()] Ping failed for " + (isRw ? cluster.rwEndpoint : cluster.roEndpoint) + " (" + (isRw ? "RW" : "RO") + "): " + e.getMessage());
+      return false;
+    }
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/DataRemoteCachePlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/DataRemoteCachePlugin.java
@@ -92,7 +92,7 @@ public class DataRemoteCachePlugin extends AbstractConnectionPlugin {
     this.malformedHintCounter = telemetryFactory.createCounter("JdbcCacheMalformedQueryHint");
     this.cacheBypassCounter = telemetryFactory.createCounter("JdbcCacheBypassCount");
     this.maxCacheableQuerySize = CACHE_MAX_QUERY_SIZE.getInteger(properties);
-    this.cacheConnection = new CacheConnection(properties);
+    this.cacheConnection = new CacheConnection(properties, this.telemetryFactory);
     this.dbUserName = PropertyDefinition.USER.getString(properties);
   }
 
@@ -145,7 +145,7 @@ public class DataRemoteCachePlugin extends AbstractConnectionPlugin {
     }
   }
 
-  private ResultSet fetchResultSetFromCache(String queryStr) {
+  private ResultSet fetchResultSetFromCache(String queryStr) throws SQLException {
     if (cacheConnection == null) return null;
 
     String cacheQueryKey = getCacheQueryKey(queryStr);
@@ -252,6 +252,7 @@ public class DataRemoteCachePlugin extends AbstractConnectionPlugin {
       final JdbcCallable<T, E> jdbcMethodFunc,
       final Object[] jdbcMethodArgs)
       throws E {
+
     if (resultClass != ResultSet.class) {
       return jdbcMethodFunc.call();
     }
@@ -285,7 +286,7 @@ public class DataRemoteCachePlugin extends AbstractConnectionPlugin {
       cacheContext = telemetryFactory.openTelemetryContext(
           TELEMETRY_CACHE_LOOKUP, TelemetryTraceLevel.TOP_LEVEL);
       Exception cacheException = null;
-      try{
+      try {
         result = fetchResultSetFromCache(mainQuery);
         if (result == null) {
           // Cache miss. Need to fetch result from the database
@@ -296,14 +297,13 @@ public class DataRemoteCachePlugin extends AbstractConnectionPlugin {
           LOGGER.finest("Got a cache hit for SQL: " + sql);
           // Cache hit. Return the cached result
           incrCounter(cacheHitCounter);
-          try {
-            result.beforeFirst();
-          } catch (final SQLException ex) {
-            cacheException = ex;
-            throw WrapperUtils.wrapExceptionIfNeeded(exceptionClass, ex);
-          }
+          result.beforeFirst();
           return resultClass.cast(result);
         }
+      } catch (final SQLException ex) {
+        // SQLException from readFromCache (failWhenCacheDown=true) or result.beforeFirst()
+        cacheException = ex;
+        throw WrapperUtils.wrapExceptionIfNeeded(exceptionClass, ex);
       } finally {
         if (cacheContext != null) {
           if (cacheException != null) {

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CacheMonitorTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CacheMonitorTest.java
@@ -1,0 +1,553 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.cache;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import io.lettuce.core.RedisCommandExecutionException;
+import io.lettuce.core.RedisConnectionException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.jdbc.util.telemetry.TelemetryCounter;
+import software.amazon.jdbc.util.telemetry.TelemetryFactory;
+import software.amazon.jdbc.util.telemetry.TelemetryGauge;
+
+public class CacheMonitorTest {
+  private Properties props;
+  private AutoCloseable closeable;
+
+  @Mock private TelemetryFactory mockTelemetryFactory;
+  @Mock private TelemetryCounter mockStateTransitionCounter;
+  @Mock private TelemetryCounter mockHealthCheckSuccessCounter;
+  @Mock private TelemetryCounter mockHealthCheckFailureCounter;
+  @Mock private TelemetryCounter mockErrorCounter;
+  @Mock private TelemetryGauge mockConsecutiveSuccessGauge;
+  @Mock private TelemetryGauge mockConsecutiveFailureGauge;
+
+  @Mock private CachePingConnection mockRwPingConnection;
+  @Mock private CachePingConnection mockRoPingConnection;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    closeable = MockitoAnnotations.openMocks(this);
+    props = new Properties();
+    props.setProperty("wrapperPlugins", "dataRemoteCache");
+    props.setProperty("cacheEndpointAddrRw", "localhost:6379");
+    props.setProperty("cacheEndpointAddrRo", "localhost:6380");
+
+    // Setup telemetry mocks
+    when(mockTelemetryFactory.createCounter("JdbcCacheStateTransitionCount"))
+        .thenReturn(mockStateTransitionCounter);
+    when(mockTelemetryFactory.createCounter("JdbcCacheHealthCheckSuccessCount"))
+        .thenReturn(mockHealthCheckSuccessCounter);
+    when(mockTelemetryFactory.createCounter("JdbcCacheHealthCheckFailureCount"))
+        .thenReturn(mockHealthCheckFailureCounter);
+    when(mockTelemetryFactory.createCounter("JdbcCacheErrorCount"))
+        .thenReturn(mockErrorCounter);
+    when(mockTelemetryFactory.createGauge(eq("JdbcCacheConsecutiveSuccessCount"), any()))
+        .thenReturn(mockConsecutiveSuccessGauge);
+    when(mockTelemetryFactory.createGauge(eq("JdbcCacheConsecutiveFailureCount"), any()))
+        .thenReturn(mockConsecutiveFailureGauge);
+
+    // Reset singleton state between tests
+    resetCacheMonitorState();
+  }
+
+  @AfterEach
+  void cleanUp() throws Exception {
+    closeable.close();
+  }
+
+  private void registerCluster(String rwEndpoint, String roEndpoint) throws Exception {
+    long inFlightLimit = CacheMonitor.CACHE_IN_FLIGHT_WRITE_SIZE_LIMIT.getLong(props);
+    boolean healthCheckInHealthy = CacheMonitor.CACHE_HEALTH_CHECK_IN_HEALTHY_STATE.getBoolean(props);
+
+    CacheMonitor.registerCluster(inFlightLimit, healthCheckInHealthy, null, rwEndpoint, roEndpoint,
+        false, Duration.ofSeconds(5), false, null, null, null, null, null, false, false);
+
+    CacheMonitor.ClusterHealthState cluster = getCluster(rwEndpoint, roEndpoint);
+    CacheMonitor instance = (CacheMonitor) getStaticField("instance");
+    if (instance != null) {
+      instance.setPingConnections(cluster, mockRwPingConnection,
+          roEndpoint != null ? mockRoPingConnection : null);
+    }
+  }
+
+  private void registerClusterWithTelemetry(String rwEndpoint, String roEndpoint) throws Exception {
+    long inFlightLimit = CacheMonitor.CACHE_IN_FLIGHT_WRITE_SIZE_LIMIT.getLong(props);
+    boolean healthCheckInHealthy = CacheMonitor.CACHE_HEALTH_CHECK_IN_HEALTHY_STATE.getBoolean(props);
+
+    CacheMonitor.registerCluster(inFlightLimit, healthCheckInHealthy, mockTelemetryFactory, rwEndpoint, roEndpoint,
+        false, Duration.ofSeconds(5), false, null, null, null, null, null, false, false);
+
+    CacheMonitor.ClusterHealthState cluster = getCluster(rwEndpoint, roEndpoint);
+    CacheMonitor instance = (CacheMonitor) getStaticField("instance");
+    if (instance != null) {
+      instance.setPingConnections(cluster, mockRwPingConnection,
+          roEndpoint != null ? mockRoPingConnection : null);
+    }
+  }
+
+  /**
+   * Reset CacheMonitor singleton state between tests using reflection
+   * to prevent test pollution from static fields.
+   */
+  private void resetCacheMonitorState() throws Exception {
+    setStaticField("instance", null);
+    setStaticField("monitorThreadStarted", false);
+
+    @SuppressWarnings("unchecked")
+    Map<String, CacheMonitor.ClusterHealthState> clusterStates =
+        (Map<String, CacheMonitor.ClusterHealthState>) getStaticField("clusterStates");
+    if (clusterStates != null) {
+      clusterStates.clear();
+    }
+
+    setStaticField("stateTransitionCounter", null);
+    setStaticField("healthCheckSuccessCounter", null);
+    setStaticField("healthCheckFailureCounter", null);
+    setStaticField("errorCounter", null);
+    setStaticField("consecutiveSuccessGauge", null);
+    setStaticField("consecutiveFailureGauge", null);
+  }
+
+  private static Object getStaticField(String fieldName) throws Exception {
+    Field field = CacheMonitor.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return field.get(null);
+  }
+
+  private static void setStaticField(String fieldName, Object value) throws Exception {
+    Field field = CacheMonitor.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(null, value);
+  }
+
+  private void setInstanceField(Object instance, String fieldName, Object value) throws Exception {
+    Field field = instance.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(instance, value);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, CacheMonitor.ClusterHealthState> getClusterStates() throws Exception {
+    return (Map<String, CacheMonitor.ClusterHealthState>) getStaticField("clusterStates");
+  }
+
+  private CacheMonitor.ClusterHealthState getCluster(String rwEndpoint, String roEndpoint) throws Exception {
+    Map<String, CacheMonitor.ClusterHealthState> clusterStates = getClusterStates();
+    String key = CacheMonitor.ClusterHealthState.generateClusterKey(rwEndpoint, roEndpoint);
+    return clusterStates.get(key);
+  }
+
+  @Test
+  void testRegisterCluster() throws Exception {
+    // Test 1: RW-only endpoint
+    registerCluster("localhost:6379", null);
+    assertEquals(1, getClusterStates().size());
+    assertEquals(CacheMonitor.HealthState.HEALTHY,
+        CacheMonitor.getClusterState("localhost:6379", null));
+
+    CacheMonitor.ClusterHealthState cluster = getCluster("localhost:6379", null);
+    assertNotNull(cluster);
+    assertEquals("localhost:6379", cluster.rwEndpoint);
+    assertNull(cluster.roEndpoint);
+    assertEquals(CacheMonitor.HealthState.HEALTHY, cluster.rwHealthState);
+    assertEquals(0, cluster.consecutiveRwSuccesses);
+    assertEquals(0, cluster.consecutiveRwFailures);
+    assertEquals(0L, cluster.inFlightWriteSizeBytes.get());
+
+    Object instance = getStaticField("instance");
+    assertNotNull(instance);
+    Boolean monitorThreadStarted = (Boolean) getStaticField("monitorThreadStarted");
+    assertFalse(monitorThreadStarted);
+
+    // Test 2: Dual endpoints
+    registerCluster("localhost:6380", "localhost:6381");
+    assertEquals(2, getClusterStates().size());
+    cluster = getCluster("localhost:6380", "localhost:6381");
+    assertNotNull(cluster);
+    assertEquals("localhost:6380", cluster.rwEndpoint);
+    assertEquals("localhost:6381", cluster.roEndpoint);
+    assertEquals(CacheMonitor.HealthState.HEALTHY, cluster.rwHealthState);
+    assertEquals(CacheMonitor.HealthState.HEALTHY, cluster.roHealthState);
+
+    // Test 3: Duplicate registration should not create duplicate
+    registerCluster("localhost:6380", "localhost:6381");
+    assertEquals(2, getClusterStates().size());
+
+    // Test 4: Same RW/RO endpoint should normalize RO to null
+    registerCluster("localhost:6382", "localhost:6382");
+    cluster = getCluster("localhost:6382", "localhost:6382");
+    assertNotNull(cluster);
+    assertNull(cluster.roEndpoint);
+    assertEquals(3, getClusterStates().size());
+  }
+
+  @Test
+  void testReportError() throws Exception {
+    registerClusterWithTelemetry("localhost:6379", "localhost:6380");
+    CacheMonitor.ClusterHealthState cluster = getCluster("localhost:6379", "localhost:6380");
+
+    // Test 1: Recoverable error transitions to SUSPECT
+    CacheMonitor.reportError("localhost:6379", "localhost:6380", true,
+        new RedisConnectionException("Connection refused"), "SET");
+    assertEquals(CacheMonitor.HealthState.SUSPECT, cluster.rwHealthState);
+    assertEquals(CacheMonitor.HealthState.HEALTHY, cluster.roHealthState);
+    verify(mockErrorCounter, times(1)).inc();
+    verify(mockStateTransitionCounter, times(1)).inc();
+
+    // Test 2: Non-recoverable error doesn't change state
+    CacheMonitor.reportError("localhost:6379", "localhost:6380", true,
+        new RuntimeException("Serialization failed"), "SET");
+    assertEquals(CacheMonitor.HealthState.SUSPECT, cluster.rwHealthState);
+    verify(mockErrorCounter, times(2)).inc();
+    verify(mockStateTransitionCounter, times(1)).inc();
+
+    // Test 3: RO endpoint error transitions independently
+    CacheMonitor.reportError("localhost:6379", "localhost:6380", false,
+        new RedisCommandExecutionException("READONLY"), "SET");
+    assertEquals(CacheMonitor.HealthState.SUSPECT, cluster.rwHealthState);
+    assertEquals(CacheMonitor.HealthState.SUSPECT, cluster.roHealthState);
+    verify(mockErrorCounter, times(3)).inc();
+    verify(mockStateTransitionCounter, times(2)).inc();
+
+    // Test 4: Unregistered cluster logs warning without metrics
+    CacheMonitor.reportError("localhost:9999", null, true,
+        new RedisConnectionException("Connection refused"), "SET");
+    verify(mockErrorCounter, times(3)).inc();
+    verify(mockStateTransitionCounter, times(2)).inc();
+  }
+
+  @Test
+  void testInFlightSize_MemoryPressureScenarios() throws Exception {
+    props.setProperty(CacheMonitor.CACHE_IN_FLIGHT_WRITE_SIZE_LIMIT.name, "1000");
+    registerClusterWithTelemetry("localhost:6379", null);
+    CacheMonitor.ClusterHealthState cluster = getCluster("localhost:6379", null);
+
+    // Test 1: Below limit remains healthy
+    CacheMonitor.incrementInFlightSizeStatic("localhost:6379", null, 500);
+    assertEquals(CacheMonitor.HealthState.HEALTHY, cluster.rwHealthState);
+    assertEquals(500L, cluster.inFlightWriteSizeBytes.get());
+
+    // Test 2: Exceeds limit transitions to degraded
+    CacheMonitor.incrementInFlightSizeStatic("localhost:6379", null, 1000);
+    assertEquals(CacheMonitor.HealthState.DEGRADED, cluster.rwHealthState);
+    assertEquals(1500L, cluster.inFlightWriteSizeBytes.get());
+    verify(mockStateTransitionCounter, times(1)).inc();
+
+    // Test 3: Decrement reduces size
+    CacheMonitor.decrementInFlightSizeStatic("localhost:6379", null, 900);
+    assertEquals(600L, cluster.inFlightWriteSizeBytes.get());
+
+    // Test 4: Decrement never goes negative
+    CacheMonitor.decrementInFlightSizeStatic("localhost:6379", null, 1000);
+    assertEquals(0L, cluster.inFlightWriteSizeBytes.get());
+  }
+
+  @Test
+  void testClusterStateAggregation() throws Exception {
+    // Test 1: Single endpoint state transitions
+    registerCluster("localhost:6379", null);
+    CacheMonitor.ClusterHealthState cluster = getCluster("localhost:6379", null);
+    assertEquals(CacheMonitor.HealthState.HEALTHY,
+        CacheMonitor.getClusterState("localhost:6379", null));
+
+    cluster.transitionToState(CacheMonitor.HealthState.SUSPECT, true, "test_setup", null);
+    assertEquals(CacheMonitor.HealthState.SUSPECT,
+        CacheMonitor.getClusterState("localhost:6379", null));
+
+    cluster.transitionToState(CacheMonitor.HealthState.DEGRADED, true, "test_setup", null);
+    assertEquals(CacheMonitor.HealthState.DEGRADED,
+        CacheMonitor.getClusterState("localhost:6379", null));
+
+    // Test 2: Dual endpoints
+    registerCluster("localhost:6379", "localhost:6380");
+    cluster = getCluster("localhost:6379", "localhost:6380");
+    assertEquals(CacheMonitor.HealthState.HEALTHY,
+        CacheMonitor.getClusterState("localhost:6379", "localhost:6380"));
+
+    cluster.transitionToState(CacheMonitor.HealthState.DEGRADED, true, "test_setup", null);
+    assertEquals(CacheMonitor.HealthState.DEGRADED,
+        CacheMonitor.getClusterState("localhost:6379", "localhost:6380"));
+
+    cluster.transitionToState(CacheMonitor.HealthState.HEALTHY, true, "test_setup", null);
+    cluster.transitionToState(CacheMonitor.HealthState.DEGRADED, false, "test_setup", null);
+    assertEquals(CacheMonitor.HealthState.DEGRADED,
+        CacheMonitor.getClusterState("localhost:6379", "localhost:6380"));
+
+    cluster.transitionToState(CacheMonitor.HealthState.SUSPECT, true, "test_setup", null);
+    cluster.transitionToState(CacheMonitor.HealthState.HEALTHY, false, "test_setup", null);
+    assertEquals(CacheMonitor.HealthState.SUSPECT,
+        CacheMonitor.getClusterState("localhost:6379", "localhost:6380"));
+
+    // Test 3: Unregistered cluster defaults to healthy
+    assertEquals(CacheMonitor.HealthState.HEALTHY,
+        CacheMonitor.getClusterState("nonexistent:9999", null));
+  }
+
+  @Test
+  void testExecutePing_StateTransitions() throws Exception {
+    registerClusterWithTelemetry("localhost:6379", null);
+    CacheMonitor.ClusterHealthState cluster = getCluster("localhost:6379", null);
+    CacheMonitor instance = (CacheMonitor) getStaticField("instance");
+
+    // Success: maintains healthy state
+    when(mockRwPingConnection.isOpen()).thenReturn(true);
+    when(mockRwPingConnection.ping()).thenReturn(true);
+    invokeExecutePing(instance, cluster, true);
+    assertEquals(CacheMonitor.HealthState.HEALTHY, cluster.rwHealthState);
+    assertEquals(1, cluster.consecutiveRwSuccesses);
+    verify(mockHealthCheckSuccessCounter, times(1)).inc();
+
+    // Failure: HEALTHY → SUSPECT
+    when(mockRwPingConnection.ping()).thenReturn(false);
+    invokeExecutePing(instance, cluster, true);
+    assertEquals(CacheMonitor.HealthState.SUSPECT, cluster.rwHealthState);
+    verify(mockHealthCheckFailureCounter, times(1)).inc();
+    verify(mockStateTransitionCounter, times(1)).inc();
+
+    // Three consecutive failures: SUSPECT → DEGRADED
+    invokeExecutePing(instance, cluster, true);
+    invokeExecutePing(instance, cluster, true);
+    invokeExecutePing(instance, cluster, true);
+    assertEquals(CacheMonitor.HealthState.DEGRADED, cluster.rwHealthState);
+    verify(mockStateTransitionCounter, times(2)).inc();
+
+    // Recovery: Three successes from SUSPECT → HEALTHY
+    cluster.transitionToState(CacheMonitor.HealthState.SUSPECT, true, "test_setup", null);
+    when(mockRwPingConnection.ping()).thenReturn(true);
+    invokeExecutePing(instance, cluster, true);
+    invokeExecutePing(instance, cluster, true);
+    invokeExecutePing(instance, cluster, true);
+    assertEquals(CacheMonitor.HealthState.HEALTHY, cluster.rwHealthState);
+    verify(mockStateTransitionCounter, times(3)).inc();
+  }
+
+  @Test
+  void testExecutePing_EdgeCases() throws Exception {
+    // Dual endpoints track independently
+    registerClusterWithTelemetry("localhost:6379", "localhost:6380");
+    CacheMonitor.ClusterHealthState cluster = getCluster("localhost:6379", "localhost:6380");
+    CacheMonitor instance = (CacheMonitor) getStaticField("instance");
+
+    when(mockRwPingConnection.isOpen()).thenReturn(true);
+    when(mockRwPingConnection.ping()).thenReturn(false);
+    when(mockRoPingConnection.isOpen()).thenReturn(true);
+    when(mockRoPingConnection.ping()).thenReturn(true);
+
+    invokeExecutePing(instance, cluster, true);
+    invokeExecutePing(instance, cluster, false);
+    assertEquals(CacheMonitor.HealthState.SUSPECT, cluster.rwHealthState);
+    assertEquals(CacheMonitor.HealthState.HEALTHY, cluster.roHealthState);
+
+    // Connection closed = failure (no ping call)
+    reset(mockRwPingConnection);
+    when(mockRwPingConnection.isOpen()).thenReturn(false);
+    invokeExecutePing(instance, cluster, true);
+    verify(mockRwPingConnection, never()).ping();
+
+    // Exception during ping = failure
+    when(mockRwPingConnection.isOpen()).thenReturn(true);
+    when(mockRwPingConnection.ping()).thenThrow(new RuntimeException("timeout"));
+    invokeExecutePing(instance, cluster, true);
+    assertEquals(CacheMonitor.HealthState.SUSPECT, cluster.rwHealthState);
+
+    // Recovery from DEGRADED when memory clears
+    resetCacheMonitorState();
+    props.setProperty(CacheMonitor.CACHE_IN_FLIGHT_WRITE_SIZE_LIMIT.name, "1000");
+    registerClusterWithTelemetry("localhost:6379", null);
+    cluster = getCluster("localhost:6379", null);
+    instance = (CacheMonitor) getStaticField("instance");
+    cluster.transitionToState(CacheMonitor.HealthState.DEGRADED, true, "test_setup", null);
+    cluster.inFlightWriteSizeBytes.set(500);
+
+    reset(mockRwPingConnection);
+    when(mockRwPingConnection.isOpen()).thenReturn(true);
+    when(mockRwPingConnection.ping()).thenReturn(true);
+    invokeExecutePing(instance, cluster, true);
+    invokeExecutePing(instance, cluster, true);
+    invokeExecutePing(instance, cluster, true);
+    assertEquals(CacheMonitor.HealthState.HEALTHY, cluster.rwHealthState);
+  }
+
+  private void invokeExecutePing(CacheMonitor instance, CacheMonitor.ClusterHealthState cluster, boolean isRw) throws Exception {
+    Method method = CacheMonitor.class.getDeclaredMethod("executePing", CacheMonitor.ClusterHealthState.class, boolean.class);
+    method.setAccessible(true);
+    method.invoke(instance, cluster, isRw);
+  }
+
+  @Test
+  void testRun_MonitoringBehavior() throws Exception {
+    when(mockRwPingConnection.isOpen()).thenReturn(true);
+    when(mockRwPingConnection.ping()).thenReturn(true);
+
+    // HEALTHY: skips ping by default
+    registerClusterWithTelemetry("localhost:6379", null);
+    CacheMonitor instance = (CacheMonitor) getStaticField("instance");
+    CacheMonitor spy = spy(instance);
+    AtomicInteger sleepCount = new AtomicInteger(0);
+    CacheMonitor finalSpy = spy;
+    doAnswer(inv -> {
+      if (sleepCount.incrementAndGet() >= 2) setInstanceField(finalSpy, "stopped", true);
+      return null;
+    }).when(spy).sleep(anyLong());
+    spy.run();
+    verify(mockRwPingConnection, never()).ping();
+
+    // HEALTHY with health check enabled: executes ping
+    resetCacheMonitorState();
+    props.setProperty(CacheMonitor.CACHE_HEALTH_CHECK_IN_HEALTHY_STATE.name, "true");
+    registerClusterWithTelemetry("localhost:6379", null);
+    instance = (CacheMonitor) getStaticField("instance");
+    spy = spy(instance);
+    sleepCount.set(0);
+    CacheMonitor finalSpy1 = spy;
+    doAnswer(inv -> {
+      if (sleepCount.incrementAndGet() >= 2) setInstanceField(finalSpy1, "stopped", true);
+      return null;
+    }).when(spy).sleep(anyLong());
+    spy.run();
+    verify(mockRwPingConnection, times(2)).ping();
+
+    // SUSPECT/DEGRADED: always pings
+    resetCacheMonitorState();
+    props.remove("cacheHealthCheckInHealthyState");
+    registerClusterWithTelemetry("localhost:6379", null);
+    CacheMonitor.ClusterHealthState cluster = getCluster("localhost:6379", null);
+    cluster.transitionToState(CacheMonitor.HealthState.SUSPECT, true, "test_setup", null);
+    instance = (CacheMonitor) getStaticField("instance");
+    spy = spy(instance);
+    sleepCount.set(0);
+    CacheMonitor finalSpy2 = spy;
+    doAnswer(inv -> {
+      if (sleepCount.incrementAndGet() >= 2) setInstanceField(finalSpy2, "stopped", true);
+      return null;
+    }).when(spy).sleep(anyLong());
+    spy.run();
+    verify(mockRwPingConnection, times(4)).ping();
+
+    // Dual endpoints: pings both
+    resetCacheMonitorState();
+    registerClusterWithTelemetry("localhost:6379", "localhost:6380");
+    cluster = getCluster("localhost:6379", "localhost:6380");
+    cluster.transitionToState(CacheMonitor.HealthState.SUSPECT, true, "test_setup", null);
+    instance = (CacheMonitor) getStaticField("instance");
+    reset(mockRwPingConnection, mockRoPingConnection);
+    when(mockRwPingConnection.isOpen()).thenReturn(true);
+    when(mockRwPingConnection.ping()).thenReturn(true);
+    when(mockRoPingConnection.isOpen()).thenReturn(true);
+    when(mockRoPingConnection.ping()).thenReturn(true);
+    spy = spy(instance);
+    sleepCount.set(0);
+    CacheMonitor finalSpy3 = spy;
+    doAnswer(inv -> {
+      if (sleepCount.incrementAndGet() >= 2) setInstanceField(finalSpy3, "stopped", true);
+      return null;
+    }).when(spy).sleep(anyLong());
+    spy.run();
+    verify(mockRwPingConnection, times(2)).ping();
+    verify(mockRoPingConnection, times(2)).ping();
+
+    // Exception during ping: continues monitoring
+    resetCacheMonitorState();
+    registerClusterWithTelemetry("localhost:6379", null);
+    cluster = getCluster("localhost:6379", null);
+    cluster.transitionToState(CacheMonitor.HealthState.SUSPECT, true, "test_setup", null);
+    instance = (CacheMonitor) getStaticField("instance");
+    reset(mockRwPingConnection);
+    when(mockRwPingConnection.isOpen()).thenReturn(true);
+    when(mockRwPingConnection.ping())
+        .thenThrow(new RuntimeException("Test exception"))
+        .thenReturn(true);
+    spy = spy(instance);
+    sleepCount.set(0);
+    CacheMonitor finalSpy4 = spy;
+    doAnswer(inv -> {
+      if (sleepCount.incrementAndGet() >= 2) setInstanceField(finalSpy4, "stopped", true);
+      return null;
+    }).when(spy).sleep(anyLong());
+    spy.run();
+    verify(mockRwPingConnection, times(2)).ping();
+  }
+
+  @Test
+  void testPrivateHelperMethods() throws Exception {
+    // Test 1: classifyError categorizes exceptions correctly
+    Method classifyMethod = CacheMonitor.class.getDeclaredMethod("classifyError", Throwable.class);
+    classifyMethod.setAccessible(true);
+
+    assertEquals(CacheMonitor.ErrorCategory.CONNECTION,
+        classifyMethod.invoke(null, new RedisConnectionException("Connection refused")));
+    assertEquals(CacheMonitor.ErrorCategory.COMMAND,
+        classifyMethod.invoke(null, new RedisCommandExecutionException("READONLY")));
+    assertEquals(CacheMonitor.ErrorCategory.COMMAND,
+        classifyMethod.invoke(null, new RedisCommandExecutionException("WRONGTYPE")));
+    assertEquals(CacheMonitor.ErrorCategory.RESOURCE,
+        classifyMethod.invoke(null, new RedisCommandExecutionException("OOM")));
+    assertEquals(CacheMonitor.ErrorCategory.RESOURCE,
+        classifyMethod.invoke(null, new RedisCommandExecutionException("CLUSTERDOWN")));
+    assertEquals(CacheMonitor.ErrorCategory.RESOURCE,
+        classifyMethod.invoke(null, new RedisCommandExecutionException((String) null)));
+    assertEquals(CacheMonitor.ErrorCategory.CONNECTION,
+        classifyMethod.invoke(null, new io.lettuce.core.RedisException("Generic error")));
+    assertEquals(CacheMonitor.ErrorCategory.DATA,
+        classifyMethod.invoke(null, new RuntimeException("Serialization failed")));
+
+    // Test 2: isRecoverableError determines recoverability
+    Method recoverableMethod = CacheMonitor.class.getDeclaredMethod("isRecoverableError", CacheMonitor.ErrorCategory.class);
+    recoverableMethod.setAccessible(true);
+
+    assertTrue((Boolean) recoverableMethod.invoke(null, CacheMonitor.ErrorCategory.CONNECTION));
+    assertTrue((Boolean) recoverableMethod.invoke(null, CacheMonitor.ErrorCategory.COMMAND));
+    assertTrue((Boolean) recoverableMethod.invoke(null, CacheMonitor.ErrorCategory.RESOURCE));
+    assertFalse((Boolean) recoverableMethod.invoke(null, CacheMonitor.ErrorCategory.DATA));
+
+    // Test 3: ping method handles various connection states
+    registerCluster("localhost:6379", null);
+    CacheMonitor.ClusterHealthState cluster = getCluster("localhost:6379", null);
+    CacheMonitor instance = (CacheMonitor) getStaticField("instance");
+
+    Method pingMethod = CacheMonitor.class.getDeclaredMethod("ping", CacheMonitor.ClusterHealthState.class, boolean.class);
+    pingMethod.setAccessible(true);
+
+    cluster.rwPingConnection = null;
+    assertFalse((Boolean) pingMethod.invoke(instance, cluster, true));
+
+    cluster.rwPingConnection = mockRwPingConnection;
+    when(mockRwPingConnection.isOpen()).thenReturn(false);
+    assertFalse((Boolean) pingMethod.invoke(instance, cluster, true));
+
+    when(mockRwPingConnection.isOpen()).thenReturn(true);
+    when(mockRwPingConnection.ping()).thenReturn(true);
+    assertTrue((Boolean) pingMethod.invoke(instance, cluster, true));
+
+    when(mockRwPingConnection.ping()).thenThrow(new RuntimeException("Ping failed"));
+    assertFalse((Boolean) pingMethod.invoke(instance, cluster, true));
+  }
+}


### PR DESCRIPTION
### Summary
Implement cache failure mode handling with health monitoring and degraded mode

### Description
This PR introduces a comprehensive cache monitoring system that detects and handles cache cluster failures gracefully, preventing cascading failures and improving system resilience.

**Key Features:**

**1. CacheMonitor Infrastructure**
- Three-state health model: HEALTHY → SUSPECT → DEGRADED
- Per-cluster state tracking with thread-safe operations
- Configurable thresholds for state transitions

**2. Health Check Monitoring**
- Background health check thread with configurable intervals (default: 5s)
- Consecutive success/failure tracking for state transitions
- Conditional health checks (skips HEALTHY clusters by default)

**3. State-Based Cache Bypass**
- Automatic cache bypass in DEGRADED state
- Transparent fallback to database on cache failures
- Continued write attempts for partial failure detection

**4. Memory Pressure Detection**
- In-flight write size tracking with configurable threshold (default: 50MB)
- Automatic transition to DEGRADED mode on memory pressure
- Recovery only when both health checks pass AND memory pressure clears

**5. Error Classification**
- Categorizes errors: CONNECTION, COMMAND, DATA, RESOURCE
- Selective error reporting (excludes DATA errors from state transitions)
- Intelligent error handling based on category

**6. Fail-Fast Mode**
- Optional `failWhenCacheDown` configuration
- Throws `CacheUnavailableException` when cache is degraded (if enabled)
- Default: graceful degradation with database fallback

**7. Comprehensive Telemetry**
- State transition metrics and logging
- Health check result tracking
- Error category metrics
- Memory pressure gauges
- Structured logging with appropriate severity levels

**8. Thread Safety**
- Atomic operations for high-frequency metrics
- Synchronized state transitions
- Volatile state reads for cross-thread visibility
- Lock-free concurrent reads from application threads

**Configuration Properties:**
- `failWhenCacheDown` (boolean, default: false)
- `cacheInFlightWriteSizeLimitBytes` (long, default: 50MB)
- `cacheHealthCheckInHealthyState` (boolean, default: false)
- `cacheHealthCheckIntervalSeconds` (int, default: 5)
- `cacheConsecutiveSuccessThreshold` (int, default: 3)
- `cacheConsecutiveFailureThreshold` (int, default: 3)

### Additional Reviewers
<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.