### PR TITLE
Caching: Glide client adaption

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -16,7 +16,9 @@
 
 plugins {
     id("me.champeau.jmh")
+    id("com.google.osdetector") version "1.7.3"
 }
+val nativeClassifier: String = osdetector.classifier
 
 dependencies {
     jmhImplementation(project(":aws-advanced-jdbc-wrapper"))
@@ -25,10 +27,7 @@ dependencies {
     implementation("org.mariadb.jdbc:mariadb-java-client:3.5.6")
     implementation("com.zaxxer:HikariCP:4.0.3")
     implementation("org.checkerframework:checker-qual:3.49.5")
-    implementation("io.lettuce:lettuce-core:6.6.0.RELEASE")
-    implementation("org.apache.commons:commons-pool2:2.11.1")
-    annotationProcessor("org.openjdk.jmh:jmh-core:1.36")
-    jmhAnnotationProcessor ("org.openjdk.jmh:jmh-generator-annprocess:1.36")
+    implementation("io.valkey:valkey-glide:2.+:$nativeClassifier")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.12.2")
     testImplementation("org.mockito:mockito-inline:4.11.0") // 4.11.0 is the last version compatible with Java 8

--- a/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/PgCacheBenchmarks.java
+++ b/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/PgCacheBenchmarks.java
@@ -128,7 +128,7 @@ public class PgCacheBenchmarks {
   public void runBenchmarkPrimaryKeyLookupWithCaching(Blackhole b) throws SQLException {
     try (Statement stmt = connection.createStatement();
          ResultSet rs = stmt.executeQuery("/*+ CACHE_PARAM(ttl=172800s) */ SELECT * FROM test where id = " + counter)) {
-         validateResultSet(rs, b);
+      validateResultSet(rs, b);
     }
     counter++;
   }

--- a/examples/AWSDriverExample/build.gradle.kts
+++ b/examples/AWSDriverExample/build.gradle.kts
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins{
+    id("com.google.osdetector") version "1.7.3" // Plugin used to detect OS and use for GLIDE
+}
+
+val nativeClassifier: String = osdetector.classifier
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-jdbc:2.7.13") // 2.7.13 is the last version compatible with Java 8
@@ -29,8 +34,8 @@ dependencies {
     implementation("com.amazonaws:aws-xray-recorder-sdk-core:2.18.2")
     implementation("org.jsoup:jsoup:1.21.1")
     implementation("com.mchange:c3p0:0.11.0")
-    implementation("io.lettuce:lettuce-core:6.6.0.RELEASE")
     implementation("org.apache.commons:commons-pool2:2.11.1")
+    implementation("io.valkey:valkey-glide:2.+:$nativeClassifier")
 }
 
 tasks.withType<JavaExec> {

--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -24,9 +24,12 @@ plugins {
     id("com.github.vlsi.ide")
     id("com.kncept.junit.reporter")
     id("com.gradleup.shadow") version "8.3.5" // 8.3.5 is the last version that is compatible with Java 8
+    id("com.google.osdetector") version "1.7.3" // Plugin used to detect OS and use for GLIDE
 }
 
 var useJacoco = (!project.hasProperty("jacocoEnabled") || project.property("jacocoEnabled").toString().toBoolean())
+
+val nativeClassifier: String = osdetector.classifier
 
 if (useJacoco) {
     apply(plugin = "org.gradle.jacoco")
@@ -47,7 +50,6 @@ dependencies {
     optionalImplementation("org.apache.commons:commons-pool2:2.11.1")
     optionalImplementation("org.jsoup:jsoup:1.21.1")
     optionalImplementation("com.amazonaws:aws-xray-recorder-sdk-core:2.18.2")
-    optionalImplementation("io.lettuce:lettuce-core:6.6.0.RELEASE")
     optionalImplementation("io.opentelemetry:opentelemetry-api:1.52.0")
     optionalImplementation("io.opentelemetry:opentelemetry-sdk:1.52.0")
     optionalImplementation("io.opentelemetry:opentelemetry-sdk-metrics:1.52.0")
@@ -58,6 +60,7 @@ dependencies {
     compileOnly("org.mariadb.jdbc:mariadb-java-client:3.5.6")
     compileOnly("org.osgi:org.osgi.core:6.0.0")
     compileOnly("org.jetbrains.kotlin:kotlin-stdlib:2.2.20")
+    compileOnly("io.valkey:valkey-glide:2.+:$nativeClassifier")
 
     // The following dependency will be included in federated-auth bundle jar.
     federatedAuthBundleImplementation("org.apache.httpcomponents:httpclient:4.5.14")
@@ -100,7 +103,6 @@ dependencies {
     testImplementation("org.slf4j:slf4j-simple:2.0.17")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:2.19.0")
     testImplementation("com.amazonaws:aws-xray-recorder-sdk-core:2.18.2")
-    testImplementation("io.lettuce:lettuce-core:6.6.0.RELEASE")
     testImplementation("io.opentelemetry:opentelemetry-api:1.52.0")
     testImplementation("io.opentelemetry:opentelemetry-sdk:1.52.0")
     testImplementation("io.opentelemetry:opentelemetry-sdk-metrics:1.52.0")
@@ -111,6 +113,7 @@ dependencies {
     testImplementation("org.hibernate:hibernate-core:5.6.15.Final") // the latest version compatible with Java 8
     testImplementation("jakarta.persistence:jakarta.persistence-api:2.2.3")
     testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.19.2")
+    testImplementation("io.valkey:valkey-glide:2.+:$nativeClassifier")
 }
 
 repositories {
@@ -131,7 +134,7 @@ java {
     withJavadocJar()
     withSourcesJar()
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
+        languageVersion.set(JavaLanguageVersion.of(11))
     }
 }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CacheConnection.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CacheConnection.java
@@ -16,28 +16,21 @@
 
 package software.amazon.jdbc.plugin.cache;
 
-import io.lettuce.core.RedisClient;
-import io.lettuce.core.RedisCredentials;
-import io.lettuce.core.RedisCredentialsProvider;
-import io.lettuce.core.RedisURI;
-import io.lettuce.core.RedisCommandExecutionException;
-import io.lettuce.core.SetArgs;
-import io.lettuce.core.SocketOptions;
-import io.lettuce.core.ReadFrom;
-import io.lettuce.core.api.StatefulConnection;
-import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.api.async.RedisAsyncCommands;
-import io.lettuce.core.cluster.ClusterClientOptions;
-import io.lettuce.core.cluster.ClusterTopologyRefreshOptions;
-import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
-import io.lettuce.core.codec.ByteArrayCodec;
-import io.lettuce.core.resource.ClientResources;
-import io.lettuce.core.cluster.RedisClusterClient;
-import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
-import io.lettuce.core.cluster.api.async.RedisAdvancedClusterAsyncCommands;
-import io.lettuce.core.resource.Delay;
-import io.lettuce.core.resource.DirContextDnsResolver;
-import reactor.core.publisher.Mono;
+import glide.api.BaseClient;
+import glide.api.GlideClient;
+import glide.api.GlideClusterClient;
+import glide.api.models.GlideString;
+import glide.api.models.commands.InfoOptions.Section;
+import glide.api.models.commands.SetOptions;
+import glide.api.models.configuration.BaseClientConfiguration;
+import glide.api.models.configuration.GlideClientConfiguration;
+import glide.api.models.configuration.GlideClusterClientConfiguration;
+import glide.api.models.configuration.AdvancedGlideClientConfiguration;
+import glide.api.models.configuration.AdvancedGlideClusterClientConfiguration;
+import glide.api.models.configuration.BackoffStrategy;
+import glide.api.models.configuration.NodeAddress;
+import glide.api.models.configuration.ReadFrom;
+import glide.api.models.configuration.ServerCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import java.nio.charset.StandardCharsets;
@@ -75,10 +68,10 @@ interface CachePingConnection {
   boolean ping();
 
   /**
-   * Checks if the connection is open.
-   * @return true if connection is open, false otherwise
+   * Checks if the client is connected.
+   * @return true if client is connected, false otherwise
    */
-  boolean isOpen();
+  boolean isConnected();
 
   /**
    * Closes the connection.
@@ -169,10 +162,10 @@ public class CacheConnection {
           "Optional prefix for cache keys (max 10 characters). Enables multi-tenant cache isolation.");
 
   // Adding support for read and write connection pools to the remote cache server
-  private volatile GenericObjectPool<StatefulConnection<byte[], byte[]>> readConnectionPool;
-  private volatile GenericObjectPool<StatefulConnection<byte[], byte[]>> writeConnectionPool;
+  private volatile GenericObjectPool<BaseClient> readConnectionPool;
+  private volatile GenericObjectPool<BaseClient> writeConnectionPool;
   // Cache endpoint registry to hold connection pools for multi end points
-  private static final ConcurrentHashMap<String, GenericObjectPool<StatefulConnection<byte[], byte[]>>> endpointToPoolRegistry = new ConcurrentHashMap<>();
+  private static final ConcurrentHashMap<String, GenericObjectPool<BaseClient>> endpointToPoolRegistry = new ConcurrentHashMap<>();
 
   private final boolean useSSL;
   private final boolean iamAuthEnabled;
@@ -197,29 +190,28 @@ public class CacheConnection {
   }
 
   /**
-   * Wraps a StatefulConnection (either StatefulRedisConnection or StatefulRedisClusterConnection)
+   * Wraps a BaseClient (either GlideClient or GlideClusterClient)
    * and exposes only ping functionality.
    */
   private static class PingConnection implements CachePingConnection {
-    private final StatefulConnection<byte[], byte[]> connection;
+    private final BaseClient connection;
 
-    PingConnection(StatefulConnection<byte[], byte[]> connection) {
+    PingConnection(BaseClient connection) {
       this.connection = connection;
     }
 
     @Override
     public boolean ping() {
       try {
-        if (!connection.isOpen()) {
+        // Cast to appropriate type to access sync() method
+        if(!connection.isConnected()){
           return false;
         }
-
-        // Cast to appropriate type to access sync() method
         String result;
-        if (connection instanceof StatefulRedisClusterConnection) {
-          result = ((StatefulRedisClusterConnection<byte[], byte[]>) connection).sync().ping();
+        if (connection instanceof GlideClusterClient) {
+          result = ((GlideClusterClient) connection).ping().get();
         } else {
-          result = ((StatefulRedisConnection<byte[], byte[]>) connection).sync().ping();
+          result = ((GlideClient) connection).ping().get();
         }
         return "PONG".equalsIgnoreCase(result);
       } catch (Exception e) {
@@ -228,8 +220,8 @@ public class CacheConnection {
     }
 
     @Override
-    public boolean isOpen() {
-      return connection.isOpen();
+    public boolean isConnected() {
+      return connection.isConnected();
     }
 
     @Override
@@ -325,14 +317,18 @@ public class CacheConnection {
     }
 
     String[] hostnameAndPort = getHostnameAndPort(this.cacheRwServerAddr);
-    RedisURI redisUri = buildRedisURI(hostnameAndPort[0], Integer.parseInt(hostnameAndPort[1]));
+    int port = Integer.parseInt(hostnameAndPort[1]);
 
-    ClientResources resources = ClientResources.builder().build();
+    BaseClientConfiguration config = buildClientConfigurationStatic(
+        hostnameAndPort[0], port, useSSL, cacheConnectionTimeout,
+        iamAuthEnabled, credentialsProvider, cacheIamRegion, cacheName, cacheUsername, cachePassword, null, false);
 
-    try (RedisClient client = RedisClient.create(resources, redisUri);
-         StatefulRedisConnection<byte[], byte[]> conn = client.connect(new ByteArrayCodec())) {
+    try (GlideClient client = GlideClient.createClient((GlideClientConfiguration) config).get()) {
 
-      String infoOutput = conn.sync().info("cluster");
+      // customCommand returns Object (usually String for INFO)
+      Section[] section = {Section.CLUSTER};
+      Object result = client.info(section).get();
+      String infoOutput = String.valueOf(result);
       boolean clusterEnabled = false;
       if (infoOutput != null) {
         // Parse the INFO output line by line
@@ -352,10 +348,6 @@ public class CacheConnection {
     } catch (Exception e) {
       LOGGER.warning("Failed to detect cluster mode, defaulting to single-shard: " + e.getMessage());
       this.isClusterMode = false;
-    } finally {
-      try {
-        resources.shutdown().get(5, TimeUnit.SECONDS);
-      } catch (Exception ignored) {}
     }
   }
 
@@ -420,25 +412,31 @@ public class CacheConnection {
         serverAddr = this.cacheRoServerAddr;
       }
       String[] hostnameAndPort = getHostnameAndPort(serverAddr);
-      RedisURI redisUri = buildRedisURI(hostnameAndPort[0], Integer.parseInt(hostnameAndPort[1]));
+      int port = Integer.parseInt(hostnameAndPort[1]);
+      String host = hostnameAndPort[0];
 
       // Appending RW and RO tag to the server address to make it unique in case RO and RW has same endpoint
       String poolKey = (isRead ? "RO:" : "RW:") + serverAddr;
-      GenericObjectPool<StatefulConnection<byte[], byte[]>> pool = endpointToPoolRegistry.get(poolKey);
+      GenericObjectPool<BaseClient> pool = endpointToPoolRegistry.get(poolKey);
 
       if (pool == null) {
-        GenericObjectPoolConfig<StatefulConnection<byte[], byte[]>> poolConfig = createPoolConfig();
+        GenericObjectPoolConfig<BaseClient> poolConfig = createPoolConfig();
         poolConfig.setMaxTotal(this.cacheConnectionPoolSize);
         poolConfig.setMaxIdle(this.cacheConnectionPoolSize);
 
         pool = endpointToPoolRegistry.computeIfAbsent(poolKey, k ->
             new GenericObjectPool<>(
-                new BasePooledObjectFactory<StatefulConnection<byte[], byte[]>>() {
-                  public StatefulConnection<byte[], byte[]> create() {
-                    return createRedisConnection(isRead, redisUri, isClusterMode);
+                new BasePooledObjectFactory<>() {
+                  public BaseClient create() throws Exception {
+                    BaseClientConfiguration config = buildClientConfiguration(host, port, isRead);
+                    if (Boolean.TRUE.equals(isClusterMode)) {
+                      return GlideClusterClient.createClient((GlideClusterClientConfiguration) config).get();
+                    } else {
+                      return GlideClient.createClient((GlideClientConfiguration) config).get();
+                    }
                   }
-                  public PooledObject<StatefulConnection<byte[], byte[]>> wrap(StatefulConnection<byte[], byte[]> connection) {
-                    return new DefaultPooledObject<>(connection);
+                  public PooledObject<BaseClient> wrap(BaseClient client) {
+                    return new DefaultPooledObject<>(client);
                   }
                 }, poolConfig)
         );
@@ -457,138 +455,139 @@ public class CacheConnection {
     }
   }
 
-  private static GenericObjectPoolConfig<StatefulConnection<byte[], byte[]>> createPoolConfig() {
-    GenericObjectPoolConfig<StatefulConnection<byte[], byte[]>> poolConfig = new GenericObjectPoolConfig<>();
+  private static GenericObjectPoolConfig<BaseClient> createPoolConfig() {
+    GenericObjectPoolConfig<BaseClient> poolConfig = new GenericObjectPoolConfig<>();
     poolConfig.setMinIdle(DEFAULT_POOL_MIN_IDLE);
     poolConfig.setMaxWait(Duration.ofMillis(DEFAULT_MAX_BORROW_WAIT_MS));
     return poolConfig;
   }
 
   /**
-   * Creates a Redis connection for either standalone or cluster mode.
-   * Returns StatefulConnection which works for both RedisClient and RedisClusterClient.
+   * Builds Glide client configuration using instance fields.
+   * Delegates to static method for actual configuration building.
    */
-  private static StatefulConnection<byte[], byte[]> createRedisConnection(
-      boolean isReadOnly, RedisURI redisUri, boolean isClusterMode) {
-
-    ClientResources resources = ClientResources.builder()
-      .dnsResolver(new DirContextDnsResolver())
-      .reconnectDelay(
-        Delay.fullJitter(
-          Duration.ofMillis(100),      // minimum 100ms delay
-          Duration.ofSeconds(10),       // maximum 10s delay
-          100, TimeUnit.MILLISECONDS))  // 100ms base
-      .build();
-
-    StatefulConnection<byte[], byte[]> conn;
-
-    if (isClusterMode) {
-      // Multi-shard cluster mode: use RedisClusterClient
-      RedisClusterClient client = RedisClusterClient.create(resources, redisUri);
-
-      // Configure cluster topology refresh per AWS best practices
-      ClusterTopologyRefreshOptions topologyRefreshOptions =
-          ClusterTopologyRefreshOptions.builder()
-          .enableAllAdaptiveRefreshTriggers()
-          .enablePeriodicRefresh()
-          .closeStaleConnections(true)
-          .build();
-
-      // Configure cluster client options per AWS best practices
-      ClusterClientOptions clusterClientOptions = ClusterClientOptions.builder()
-          .topologyRefreshOptions(topologyRefreshOptions)
-          .nodeFilter(node ->
-            !(node.is(RedisClusterNode.NodeFlag.FAIL)
-              || node.is(RedisClusterNode.NodeFlag.EVENTUAL_FAIL)
-              || node.is(RedisClusterNode.NodeFlag.HANDSHAKE)
-              || node.is(RedisClusterNode.NodeFlag.NOADDR)))
-          .validateClusterNodeMembership(false)
-          .autoReconnect(true)
-          .socketOptions(SocketOptions.builder()
-              .keepAlive(true)
-              .build())
-          .build();
-
-      client.setOptions(clusterClientOptions);
-
-      // Connect and configure ReadFrom for replica reads
-      StatefulRedisClusterConnection<byte[], byte[]> clusterConn = client.connect(new ByteArrayCodec());
-
-      // Configure read preference: replicas for RO connections, master for RW
-      if (isReadOnly) {
-        clusterConn.setReadFrom(ReadFrom.REPLICA_PREFERRED);
-      } else {
-        clusterConn.setReadFrom(ReadFrom.MASTER);
-      }
-
-      conn = clusterConn;
-    } else {
-      // Single-shard standalone mode: use RedisClient
-      RedisClient client = RedisClient.create(resources, redisUri);
-      conn = client.connect(new ByteArrayCodec());
-    }
-
-    // Set READONLY mode for RO endpoint
-    if (isReadOnly) {
-      try {
-        if (conn instanceof StatefulRedisClusterConnection) {
-          ((StatefulRedisClusterConnection<byte[], byte[]>) conn).sync().readOnly();
-        } else {
-          ((StatefulRedisConnection<byte[], byte[]>) conn).sync().readOnly();
-        }
-      } catch (RedisCommandExecutionException e) {
-        if (e.getMessage().contains("ERR This instance has cluster support disabled")) {
-          LOGGER.fine("Note: this cache cluster has cluster support disabled");
-        } else {
-          LOGGER.fine("Note: READONLY command not supported or failed: " + e.getMessage());
-        }
-      }
-    }
-
-    return conn;
+  protected BaseClientConfiguration buildClientConfiguration(String hostname, int port, Boolean isRead) {
+    return buildClientConfigurationStatic(hostname, port, this.useSSL, this.cacheConnectionTimeout,
+        this.iamAuthEnabled, this.credentialsProvider, this.cacheIamRegion, this.cacheName,
+        this.cacheUsername, this.cachePassword, isRead, this.isClusterMode);
   }
 
   /**
-   * Static helper to build RedisURI with authentication configuration.
-   * Used by both createPingConnection (static) and buildRedisURI (instance).
+   * Builds Glide client configuration for standalone or cluster mode.
+   * Returns GlideClientConfiguration for standalone or GlideClusterClientConfiguration for cluster mode.
+   *
+   * @param isRead true for read-only replica connections, false for primary connections
+   * @param isClusterMode true for cluster mode (CME), false for standalone mode (CMD)
+   * @return BaseClientConfiguration configured for the specified mode
    */
-  private static RedisURI buildRedisURIStatic(String hostname, int port, boolean useSSL, Duration connectionTimeout,
-      boolean iamAuthEnabled, AwsCredentialsProvider credentialsProvider, String cacheIamRegion,
-      String cacheName, String cacheUsername, String cachePassword) {
+  protected static BaseClientConfiguration buildClientConfigurationStatic(
+      String hostname, int port, boolean useSSL, Duration connectionTimeout,
+      boolean iamAuthEnabled, AwsCredentialsProvider credentialsProvider,
+      String cacheIamRegion, String cacheName, String cacheUsername,
+      String cachePassword, Boolean isRead, Boolean isClusterMode) {
 
-    RedisURI.Builder uriBuilder = RedisURI.Builder.redis(hostname)
-        .withPort(port)
-        .withSsl(useSSL)
-        .withVerifyPeer(false)
-        .withLibraryName("aws-sql-jdbc-lettuce")
-        .withTimeout(connectionTimeout);
+    NodeAddress address = buildNodeAddress(hostname, port);
+    ServerCredentials credentials = buildServerCredentials(
+        iamAuthEnabled, credentialsProvider, cacheIamRegion, cacheName,
+        hostname, port, cacheUsername, cachePassword);
+
+    // checks for cluster mode and returns appropriate client configuration
+    if (Boolean.TRUE.equals(isClusterMode)) {
+      GlideClusterClientConfiguration.GlideClusterClientConfigurationBuilder builder =
+          GlideClusterClientConfiguration.builder()
+              .address(address)
+              .useTLS(useSSL)
+              .libName("aws-sql-jdbc-glide")
+              .requestTimeout((int) connectionTimeout.toMillis())
+              .lazyConnect(true)
+              .readFrom(Boolean.TRUE.equals(isRead) ? ReadFrom.PREFER_REPLICA : ReadFrom.PRIMARY)
+              .reconnectStrategy(reconnectStrategyBuilder());
+
+      if (useSSL) {
+        builder.advancedConfiguration(
+            AdvancedGlideClusterClientConfiguration.builder()
+                .connectionTimeout((int) connectionTimeout.toMillis())
+                .build());
+      }
+      if (credentials != null) {
+        builder.credentials(credentials);
+      }
+      return builder.build();
+    } else {
+      GlideClientConfiguration.GlideClientConfigurationBuilder builder =
+          GlideClientConfiguration.builder()
+              .address(address)
+              .useTLS(useSSL)
+              .libName("aws-sql-jdbc-glide")
+              .requestTimeout((int) connectionTimeout.toMillis())
+              .lazyConnect(true)
+              .readFrom(Boolean.TRUE.equals(isRead) ? ReadFrom.PREFER_REPLICA : ReadFrom.PRIMARY)
+              .reconnectStrategy(reconnectStrategyBuilder());
+
+      if (useSSL) {
+        builder.advancedConfiguration(
+            AdvancedGlideClientConfiguration.builder()
+                .connectionTimeout((int) connectionTimeout.toMillis())
+                .build());
+      }
+      if (credentials != null) {
+        builder.credentials(credentials);
+      }
+      return builder.build();
+    }
+  }
+
+  // Builds NodeAddress for Glide clients
+  private static NodeAddress buildNodeAddress(String hostname, int port) {
+    return NodeAddress.builder()
+        .host(hostname)
+        .port(port)
+        .build();
+  }
+
+  // Builds ServerCredentials for IAM or password-based authentication.
+  private static ServerCredentials buildServerCredentials(
+      boolean iamAuthEnabled, AwsCredentialsProvider credentialsProvider,
+      String cacheIamRegion, String cacheName, String hostname, int port,
+      String cacheUsername, String cachePassword) {
 
     if (iamAuthEnabled) {
-      // Create a credentials provider that Lettuce will call whenever authentication is needed
-      RedisCredentialsProvider redisCredentialsProvider = () -> {
-        // Create a cached token supplier that automatically refreshes tokens every 14.5 minutes
-        Supplier<String> tokenSupplier = CachedSupplier.memoizeWithExpiration(
-            () -> {
-              ElastiCacheIamTokenUtility tokenUtility = new ElastiCacheIamTokenUtility(cacheName);
-              return tokenUtility.generateAuthenticationToken(
-                  credentialsProvider,
-                  Region.of(cacheIamRegion),
-                  hostname,
-                  port,
-                  cacheUsername
-              );
-            },
-            TOKEN_CACHE_DURATION,
-            TimeUnit.SECONDS
-        );
-        return Mono.just(RedisCredentials.just(cacheUsername, tokenSupplier.get()));
-      };
-      uriBuilder.withAuthentication(redisCredentialsProvider);
-    } else if (!StringUtils.isNullOrEmpty(cachePassword)) {
-      uriBuilder.withAuthentication(cacheUsername, cachePassword);
-    }
+      Supplier<String> tokenSupplier = CachedSupplier.memoizeWithExpiration(
+          () -> {
+            ElastiCacheIamTokenUtility tokenUtility = new ElastiCacheIamTokenUtility(cacheName);
+            return tokenUtility.generateAuthenticationToken(
+                credentialsProvider,
+                Region.of(cacheIamRegion),
+                hostname,
+                port,
+                cacheUsername
+            );
+          },
+          TOKEN_CACHE_DURATION,
+          TimeUnit.SECONDS
+      );
 
-    return uriBuilder.build();
+      return ServerCredentials.builder()
+          .username(cacheUsername)
+          .password(tokenSupplier.get())
+          .build();
+    } else if (!StringUtils.isNullOrEmpty(cachePassword)) {
+      return ServerCredentials.builder()
+          .username(cacheUsername)
+          .password(cachePassword)
+          .build();
+    }
+    return null;
+  }
+
+  // Builds exponential backoff strategy for connection retries.
+  private static BackoffStrategy reconnectStrategyBuilder() {
+    return BackoffStrategy.builder()
+        .numOfRetries(5)
+        .exponentBase(2)
+        .factor(100)
+        .jitterPercent(20)
+        .build();
   }
 
   /**
@@ -601,16 +600,14 @@ public class CacheConnection {
       String cacheName, String cacheUsername, String cachePassword) {
 
     try {
-      // Use the static helper to build RedisURI
-      RedisURI redisUri = buildRedisURIStatic(hostname, port, useSSL, connectionTimeout, iamAuthEnabled,
-          credentialsProvider, cacheIamRegion, cacheName, cacheUsername, cachePassword
+      // Creating GlideClient (use standalone for ping - works for both)
+      BaseClientConfiguration config = buildClientConfigurationStatic(
+          hostname, port, useSSL, connectionTimeout, iamAuthEnabled,
+          credentialsProvider, cacheIamRegion, cacheName, cacheUsername, cachePassword, null, false
       );
-      // Create Lettuce connection (use standalone mode for ping - works for both)
-      StatefulConnection<byte[], byte[]> conn = createRedisConnection(isReadOnly, redisUri, false);
 
-      // Wrap in abstraction interface
-      return new PingConnection(conn);
-
+      BaseClient client = GlideClient.createClient((GlideClientConfiguration) config).get();
+      return new PingConnection(client);
     } catch (Exception e) {
       LOGGER.fine(String.format("Failed to create ping connection for %s:%d: %s",
           hostname, port, e.getMessage()));
@@ -649,21 +646,17 @@ public class CacheConnection {
     }
 
     boolean isBroken = false;
-    StatefulConnection<byte[], byte[]> conn = null;
+    BaseClient client = null;
     // get a connection from the read connection pool
     try {
       initializeCacheConnectionIfNeeded(true);
-      conn = this.readConnectionPool.borrowObject();
-
-      // Cast to appropriate type and execute get command
+      client = this.readConnectionPool.borrowObject();
       byte[] cacheKey = computeCacheKey(key);
-      if (conn instanceof StatefulRedisClusterConnection) {
-        return ((StatefulRedisClusterConnection<byte[], byte[]>) conn).sync().get(cacheKey);
-      } else {
-        return ((StatefulRedisConnection<byte[], byte[]>) conn).sync().get(cacheKey);
-      }
+      GlideString keyGs = GlideString.of(cacheKey);
+      GlideString gs = client.get(keyGs).get();
+      return (gs != null) ? gs.getBytes() : null;
     } catch (Exception e) {
-      if (conn != null) {
+      if (client != null) {
         isBroken = true;
       }
       // Report error to CacheMonitor for the read endpoint
@@ -671,9 +664,9 @@ public class CacheConnection {
       LOGGER.warning("Failed to read result from cache. Treating it as a cache miss: " + e.getMessage());
       return null;
     } finally {
-      if (conn != null && this.readConnectionPool != null) {
+      if (client != null && this.readConnectionPool != null) {
         try {
-          this.returnConnectionBackToPool(conn, isBroken, true);
+          this.returnConnectionBackToPool(client, isBroken, true);
         } catch (Exception ex) {
           LOGGER.warning("Error closing read connection: " + ex.getMessage());
         }
@@ -681,7 +674,7 @@ public class CacheConnection {
     }
   }
 
-  protected void handleCompletedCacheWrite(StatefulConnection<byte[], byte[]> conn, long writeSize, Throwable ex) {
+  protected void handleCompletedCacheWrite(BaseClient client, long writeSize, Throwable ex) {
     // Note: this callback upon completion of cache write is on a different thread
     // Always decrement in-flight size (write completed, whether success or failure)
     decrementInFlightSize(writeSize);
@@ -691,7 +684,7 @@ public class CacheConnection {
       reportErrorToCacheMonitor(true, ex, "WRITE");
       if (this.writeConnectionPool != null) {
         try {
-          returnConnectionBackToPool(conn, true, false);
+          returnConnectionBackToPool(client, true, false);
         } catch (Exception e) {
           LOGGER.warning("Error returning broken write connection back to pool: " + e.getMessage());
         }
@@ -699,7 +692,7 @@ public class CacheConnection {
     } else {
       if (this.writeConnectionPool != null) {
         try {
-          returnConnectionBackToPool(conn, false, false);
+          returnConnectionBackToPool(client, false, false);
         } catch (Exception e) {
           LOGGER.warning("Error returning write connection back to pool: " + e.getMessage());
         }
@@ -715,7 +708,7 @@ public class CacheConnection {
       return; // Exit without writing
     }
 
-    StatefulConnection<byte[], byte[]> conn = null;
+    BaseClient client = null;
     try {
       initializeCacheConnectionIfNeeded(false);
 
@@ -725,7 +718,7 @@ public class CacheConnection {
       incrementInFlightSize(writeSize);
 
       try {
-        conn = this.writeConnectionPool.borrowObject();
+        client = this.writeConnectionPool.borrowObject();
       } catch (Exception borrowException) {
         // Connection borrow failed (timeout/pool exhaustion) - decrement immediately
         decrementInFlightSize(writeSize);
@@ -734,27 +727,21 @@ public class CacheConnection {
       }
 
       // Get async commands and execute set operation based on connection type
-      StatefulConnection<byte[], byte[]> finalConn = conn;
+      BaseClient finalClient = client;
 
-      if (conn instanceof StatefulRedisClusterConnection) {
-        RedisAdvancedClusterAsyncCommands<byte[], byte[]> clusterAsyncCommands =
-            ((StatefulRedisClusterConnection<byte[], byte[]>) conn).async();
-        clusterAsyncCommands.set(cacheKey, value, SetArgs.Builder.ex(expiry))
-            .whenComplete((result, exception) -> handleCompletedCacheWrite(finalConn, writeSize, exception));
-      } else {
-        RedisAsyncCommands<byte[], byte[]> asyncCommands =
-            ((StatefulRedisConnection<byte[], byte[]>) conn).async();
-        asyncCommands.set(cacheKey, value, SetArgs.Builder.ex(expiry))
-            .whenComplete((result, exception) -> handleCompletedCacheWrite(finalConn, writeSize, exception));
-      }
+      GlideString keyGs = GlideString.of(cacheKey);
+      GlideString valueGs = GlideString.of(value);
+      SetOptions options = SetOptions.builder().expiry(SetOptions.Expiry.Seconds((long) expiry)).build();
 
+      client.set(keyGs, valueGs, options)
+          .whenComplete((result, exception) -> handleCompletedCacheWrite(finalClient, writeSize, exception));
     } catch (Exception e) {
       // Connection failed, but we already incremented and will be able to detect shard level failures
       reportErrorToCacheMonitor(true, e, "WRITE");
 
-      if (conn != null && this.writeConnectionPool != null) {
+      if (client != null && this.writeConnectionPool != null) {
         try {
-          returnConnectionBackToPool(conn, true, false);
+          returnConnectionBackToPool(client, true, false);
         } catch (Exception ex) {
           LOGGER.warning("Error closing write connection: " + ex.getMessage());
         }
@@ -762,10 +749,10 @@ public class CacheConnection {
     }
   }
 
-  private void returnConnectionBackToPool(StatefulConnection<byte[], byte[]> connection, boolean isConnectionBroken, boolean isRead) {
-    GenericObjectPool<StatefulConnection<byte[], byte[]>> pool = isRead ? this.readConnectionPool : this.writeConnectionPool;
+  private void returnConnectionBackToPool(BaseClient connection, boolean isConnectionBroken, boolean isRead) {
+    GenericObjectPool<BaseClient> pool = isRead ? this.readConnectionPool : this.writeConnectionPool;
     if (isConnectionBroken) {
-      if (!connection.isOpen()) {
+      if (!connection.isConnected()) {
         try {
           pool.invalidateObject(connection);
           return;
@@ -777,13 +764,6 @@ public class CacheConnection {
       }
     }
     pool.returnObject(connection);
-  }
-
-  protected RedisURI buildRedisURI(String hostname, int port) {
-    // Delegate to the static helper
-    return buildRedisURIStatic(hostname, port, this.useSSL, this.cacheConnectionTimeout, this.iamAuthEnabled,
-        this.credentialsProvider, this.cacheIamRegion, this.cacheName, this.cacheUsername, this.cachePassword
-    );
   }
 
   private String[] getHostnameAndPort(String serverAddr) {
@@ -814,8 +794,8 @@ public class CacheConnection {
   }
 
   // Used for unit testing only
-  protected void setConnectionPools(GenericObjectPool<StatefulConnection<byte[], byte[]>> readPool,
-      GenericObjectPool<StatefulConnection<byte[], byte[]>> writePool) {
+  protected void setConnectionPools(GenericObjectPool<BaseClient> readPool,
+      GenericObjectPool<BaseClient> writePool) {
     this.readConnectionPool = readPool;
     this.writeConnectionPool = writePool;
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CacheMonitor.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CacheMonitor.java
@@ -17,13 +17,18 @@
 package software.amazon.jdbc.plugin.cache;
 
 import java.util.Map;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Logger;
-import io.lettuce.core.RedisCommandExecutionException;
-import io.lettuce.core.RedisConnectionException;
-import io.lettuce.core.RedisException;
+import glide.api.models.exceptions.ClosingException;
+import glide.api.models.exceptions.ConfigurationError;
+import glide.api.models.exceptions.ConnectionException;
+import glide.api.models.exceptions.GlideException;
+import glide.api.models.exceptions.RequestException;
+import glide.api.models.exceptions.TimeoutException;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import java.time.Duration;
 import software.amazon.jdbc.AwsWrapperProperty;
@@ -338,22 +343,46 @@ public class CacheMonitor implements Runnable {
   }
 
   private static ErrorCategory classifyError(Throwable error) {
-    if (error instanceof RedisConnectionException) {
+    // 1. Unwrap Async Wrappers (Common in Glide)
+    if (error instanceof ExecutionException || error instanceof CompletionException) {
+      if (error.getCause() != null) {
+        error = error.getCause();
+      }
+    }
+    // Connection-related errors
+    if (error instanceof ClosingException ||
+        error instanceof TimeoutException ||
+        error instanceof ConnectionException) {
       return ErrorCategory.CONNECTION;
     }
-    if (error instanceof RedisCommandExecutionException) {
+
+    if (error instanceof ConfigurationError) {
+      return ErrorCategory.RESOURCE;
+    }
+
+    // Request/Command errors
+    if (error instanceof RequestException) {
       String msg = error.getMessage();
       if (msg == null) return ErrorCategory.RESOURCE;
-      if (msg.contains("READONLY") || msg.contains("WRONGTYPE") || msg.contains("MOVED") || msg.contains("ASK")) {
+      msg = msg.toUpperCase();
+
+      // Command-specific errors
+      if (msg.contains("READONLY") || msg.contains("WRONGTYPE") ||
+          msg.contains("MOVED") || msg.contains("ASK")) {
         return ErrorCategory.COMMAND;
       }
-      if (msg.contains("OOM") || msg.contains("CLUSTERDOWN") || msg.contains("LOADING") ||
-          msg.contains("NOAUTH") || msg.contains("WRONGPASS")) {
+
+      // Resource/availability errors
+      if (msg.contains("OOM") || msg.contains("CLUSTERDOWN") ||
+          msg.contains("LOADING") || msg.contains("NOAUTH") ||
+          msg.contains("WRONGPASS")) {
         return ErrorCategory.RESOURCE;
       }
       return ErrorCategory.COMMAND;
     }
-    if (error instanceof RedisException) {
+
+    // General GLIDE errors
+    if (error instanceof GlideException) {
       return ErrorCategory.CONNECTION;
     }
     return ErrorCategory.DATA;
@@ -514,7 +543,7 @@ public class CacheMonitor implements Runnable {
 
   private boolean ping(ClusterHealthState cluster, boolean isRw) {
     CachePingConnection conn = isRw ? cluster.rwPingConnection : cluster.roPingConnection;
-    if (conn == null || !conn.isOpen()) {
+    if(conn == null || !conn.isConnected()) {
       return false;
     }
     try {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/DataRemoteCachePlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/DataRemoteCachePlugin.java
@@ -81,7 +81,7 @@ public class DataRemoteCachePlugin extends AbstractConnectionPlugin {
 
   public DataRemoteCachePlugin(final PluginService pluginService, final Properties properties) {
     try {
-      Class.forName("io.lettuce.core.RedisClient"); // Lettuce dependency
+      Class.forName("glide.api.GlideClient"); // Glide client dependency
       Class.forName("org.apache.commons.pool2.impl.GenericObjectPool"); // Object pool dependency
     } catch (final ClassNotFoundException e) {
       throw new RuntimeException(Messages.get("DataRemoteCachePlugin.notInClassPath", new Object[] {e.getMessage()}));

--- a/wrapper/src/test/build.gradle.kts
+++ b/wrapper/src/test/build.gradle.kts
@@ -59,7 +59,6 @@ dependencies {
     testImplementation("io.opentelemetry:opentelemetry-sdk:1.42.1")
     testImplementation("io.opentelemetry:opentelemetry-sdk-metrics:1.43.0")
     testImplementation("io.opentelemetry:opentelemetry-exporter-otlp:1.44.1")
-    testImplementation("io.lettuce:lettuce-core:6.6.0.RELEASE")
     testImplementation("de.vandermeer:asciitable:0.3.2")
     testImplementation("org.hibernate:hibernate-core:5.6.15.Final") // the latest version compatible with Java 8
     testImplementation("jakarta.persistence:jakarta.persistence-api:2.2.3")

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CacheConnectionTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CacheConnectionTest.java
@@ -16,15 +16,12 @@
 
 package software.amazon.jdbc.plugin.cache;
 
-import io.lettuce.core.RedisFuture;
-import io.lettuce.core.RedisURI;
-import io.lettuce.core.api.StatefulConnection;
-import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.api.async.RedisAsyncCommands;
-import io.lettuce.core.api.sync.RedisCommands;
-import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
-import io.lettuce.core.cluster.api.async.RedisAdvancedClusterAsyncCommands;
-import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
+import glide.api.BaseClient;
+import glide.api.GlideClient;
+import glide.api.GlideClusterClient;
+import glide.api.models.GlideString;
+import glide.api.models.commands.SetOptions;
+import glide.api.models.configuration.BaseClientConfiguration;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,6 +39,8 @@ import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.Properties;
 
@@ -49,15 +48,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 public class CacheConnectionTest {
-  @Mock GenericObjectPool<StatefulConnection<byte[], byte[]>> mockReadConnPool;
-  @Mock GenericObjectPool<StatefulConnection<byte[], byte[]>> mockWriteConnPool;
-  @Mock StatefulRedisConnection<byte[], byte[]> mockConnection;
-  @Mock RedisCommands<byte[], byte[]> mockSyncCommands;
-  @Mock RedisAsyncCommands<byte[], byte[]> mockAsyncCommands;
-  @Mock StatefulRedisClusterConnection<byte[], byte[]> mockClusterConnection;
-  @Mock RedisAdvancedClusterCommands<byte[], byte[]> mockClusterSyncCommands;
-  @Mock RedisAdvancedClusterAsyncCommands<byte[], byte[]> mockClusterAsyncCommands;
-  @Mock RedisFuture<String> mockCacheResult;
+  @Mock GenericObjectPool<BaseClient> mockReadConnPool;
+  @Mock GenericObjectPool<BaseClient> mockWriteConnPool;
+  @Mock GlideClient mockClient;
+  @Mock GlideClusterClient mockClusterClient;
+  @Mock CompletableFuture<String> mockCacheResult;
   private AutoCloseable closeable;
   private CacheConnection cacheConnection;
 
@@ -240,34 +235,37 @@ public class CacheConnectionTest {
   }
 
   @Test
-  void testBuildRedisURI_IamAuth() {
+  void testBuildGlideConfig_IamAuth() {
     Properties props = new Properties();
     props.setProperty("cacheEndpointAddrRw", "localhost:6379");
     props.setProperty("cacheIamRegion", "us-east-1");
     props.setProperty("cacheUsername", "testuser");
     props.setProperty("cacheName", "test-cache");
 
-    try (MockedConstruction<ElastiCacheIamTokenUtility> mockedTokenUtility = mockConstruction(ElastiCacheIamTokenUtility.class)) {
+    try (MockedConstruction<ElastiCacheIamTokenUtility> mockedTokenUtility = mockConstruction(ElastiCacheIamTokenUtility.class,
+        (mock, context) -> {
+          when(mock.generateAuthenticationToken(
+              any(AwsCredentialsProvider.class),
+              any(Region.class),
+              anyString(),
+              anyInt(),
+              anyString()
+          )).thenReturn("mock-iam-token");
+        })) {
 
       CacheConnection connection = new CacheConnection(props);
-      RedisURI uri = connection.buildRedisURI("localhost", 6379);
+      BaseClientConfiguration config = connection.buildClientConfiguration("localhost", 6379, false);
 
-      // Verify URI properties
-      assertNotNull(uri);
-      assertEquals("localhost", uri.getHost());
-      assertEquals(6379, uri.getPort());
-      assertTrue(uri.isSsl());
-      assertNotNull(uri.getCredentialsProvider());
+      // Verify Configuration properties
+      assertNotNull(config);
+      assertEquals("localhost", config.getAddresses().get(0).getHost());
+      assertEquals(6379, config.getAddresses().get(0).getPort());
+      assertTrue(config.isUseTLS());
+      assertNotNull(config.getCredentials());
 
-      // Trigger the credentials provider to create the token utility
-      uri.getCredentialsProvider().resolveCredentials().block();
-
-      // Verify URI properties
-      assertNotNull(uri);
-      assertEquals("localhost", uri.getHost());
-      assertEquals(6379, uri.getPort());
-      assertTrue(uri.isSsl());
-      assertNotNull(uri.getCredentialsProvider()); // IAM credentials provider set
+      // Verify token was actually retrieved (equivalent to .block())
+      assertEquals("testuser", config.getCredentials().getUsername());
+      assertEquals("mock-iam-token", config.getCredentials().getPassword());
 
       // Verify ElastiCacheIamTokenUtility was constructed with correct parameters
       // Verify token utility construction
@@ -284,35 +282,34 @@ public class CacheConnectionTest {
   }
 
   @Test
-  void testBuildRedisURI_TraditionalAuth() {
+  void testBuildGlideConfig_TraditionalAuth() {
     Properties props = new Properties();
     props.setProperty("cacheEndpointAddrRw", "localhost:6379");
     props.setProperty("cacheUsername", "user");
     props.setProperty("cachePassword", "pass");
 
     CacheConnection connection = new CacheConnection(props);
-    RedisURI uri = connection.buildRedisURI("localhost", 6379);
+    BaseClientConfiguration config = connection.buildClientConfiguration("localhost", 6379, false);
 
-    assertNotNull(uri);
-    assertEquals("localhost", uri.getHost());
-    assertEquals(6379, uri.getPort());
-    assertEquals("user", uri.getUsername());
-    assertEquals("pass", new String(uri.getPassword()));
+    assertNotNull(config);
+    assertEquals("localhost", config.getAddresses().get(0).getHost());
+    assertEquals(6379, config.getAddresses().get(0).getPort());
+    assertEquals("user", config.getCredentials().getUsername());
+    assertEquals("pass", config.getCredentials().getPassword());
   }
 
   @Test
-  void testBuildRedisURI_NoAuth() {
+  void testBuildGlideConfig_NoAuth() {
     Properties props = new Properties();
     props.setProperty("cacheEndpointAddrRw", "localhost:6379");
 
     CacheConnection connection = new CacheConnection(props);
-    RedisURI uri = connection.buildRedisURI("localhost", 6379);
+    BaseClientConfiguration config = connection.buildClientConfiguration("localhost", 6379, false);
 
-    assertNotNull(uri);
-    assertEquals("localhost", uri.getHost());
-    assertEquals(6379, uri.getPort());
-    assertNull(uri.getUsername());
-    assertNull(uri.getPassword());
+    assertNotNull(config);
+    assertEquals("localhost", config.getAddresses().get(0).getHost());
+    assertEquals(6379, config.getAddresses().get(0).getPort());
+    assertNull(config.getCredentials());
   }
 
   @Test
@@ -325,14 +322,12 @@ public class CacheConnectionTest {
 
     String key = "myQueryKey";
     byte[] value = "myValue".getBytes(StandardCharsets.UTF_8);
-    when(mockWriteConnPool.borrowObject()).thenReturn(mockConnection);
-    when(mockConnection.async()).thenReturn(mockAsyncCommands);
-    when(mockAsyncCommands.set(any(), any(), any())).thenReturn(mockCacheResult);
+    when(mockWriteConnPool.borrowObject()).thenReturn(mockClient);
+    when(mockClient.set(any(GlideString.class), any(GlideString.class), any(SetOptions.class))).thenReturn(mockCacheResult);
     when(mockCacheResult.whenComplete(any(BiConsumer.class))).thenReturn(null);
     spyConnection.writeToCache(key, value, 100);
     verify(mockWriteConnPool).borrowObject();
-    verify(mockConnection).async();
-    verify(mockAsyncCommands).set(any(), any(), any());
+    verify(mockClient).set(any(GlideString.class), any(GlideString.class), any(SetOptions.class));
     verify(mockCacheResult).whenComplete(any(BiConsumer.class));
   }
 
@@ -346,14 +341,13 @@ public class CacheConnectionTest {
 
     String key = "myQueryKey";
     byte[] value = "myValue".getBytes(StandardCharsets.UTF_8);
-    when(mockWriteConnPool.borrowObject()).thenReturn(mockConnection);
-    when(mockConnection.async()).thenReturn(mockAsyncCommands);
-    when(mockAsyncCommands.set(any(), any(), any())).thenThrow(new RuntimeException("test exception"));
+    when(mockWriteConnPool.borrowObject()).thenReturn(mockClient);
+    when(mockClient.set(any(GlideString.class), any(GlideString.class), any(SetOptions.class)))
+        .thenThrow(new RuntimeException("test exception"));
     spyConnection.writeToCache(key, value, 100);
     verify(mockWriteConnPool).borrowObject();
-    verify(mockConnection).async();
-    verify(mockAsyncCommands).set(any(), any(), any());
-    verify(mockWriteConnPool).invalidateObject(mockConnection);
+    verify(mockClient).set(any(GlideString.class), any(GlideString.class), any(SetOptions.class));
+    verify(mockWriteConnPool).invalidateObject(mockClient);
   }
 
   @Test
@@ -363,25 +357,25 @@ public class CacheConnectionTest {
     doNothing().when(spyConnection).reportErrorToCacheMonitor(anyBoolean(), any(), any());
 
     // Success: decrement called, no error reported, connection returned
-    spyConnection.handleCompletedCacheWrite(mockConnection, 150L, null);
+    spyConnection.handleCompletedCacheWrite(mockClient, 150L, null);
     verify(spyConnection).decrementInFlightSize(150L);
     verify(spyConnection, never()).reportErrorToCacheMonitor(anyBoolean(), any(), any());
-    verify(mockWriteConnPool).returnObject(mockConnection);
+    verify(mockWriteConnPool).returnObject(mockClient);
 
     // Failure: decrement called, error reported, connection invalidated
     RuntimeException writeError = new RuntimeException("Redis timeout");
-    spyConnection.handleCompletedCacheWrite(mockConnection, 200L, writeError);
+    spyConnection.handleCompletedCacheWrite(mockClient, 200L, writeError);
     verify(spyConnection).decrementInFlightSize(200L);
     verify(spyConnection).reportErrorToCacheMonitor(eq(true), eq(writeError), eq("WRITE"));
-    verify(mockWriteConnPool).invalidateObject(mockConnection);
+    verify(mockWriteConnPool).invalidateObject(mockClient);
 
     // Multiple operations: mixed success/failure
-    spyConnection.handleCompletedCacheWrite(mockConnection, 100L, null);
-    spyConnection.handleCompletedCacheWrite(mockConnection, 250L, new RuntimeException("lost"));
+    spyConnection.handleCompletedCacheWrite(mockClient, 100L, null);
+    spyConnection.handleCompletedCacheWrite(mockClient, 250L, new RuntimeException("lost"));
     verify(spyConnection).decrementInFlightSize(100L);
     verify(spyConnection).decrementInFlightSize(250L);
-    verify(mockWriteConnPool, times(2)).returnObject(mockConnection);
-    verify(mockWriteConnPool, times(2)).invalidateObject(mockConnection);
+    verify(mockWriteConnPool, times(2)).returnObject(mockClient);
+    verify(mockWriteConnPool, times(2)).invalidateObject(mockClient);
   }
 
   @Test
@@ -391,15 +385,14 @@ public class CacheConnectionTest {
     doNothing().when(spyConnection).reportErrorToCacheMonitor(anyBoolean(), any(), any());
 
     byte[] value = "myValue".getBytes(StandardCharsets.UTF_8);
-    when(mockReadConnPool.borrowObject()).thenReturn(mockConnection);
-    when(mockConnection.sync()).thenReturn(mockSyncCommands);
-    when(mockSyncCommands.get(any())).thenReturn(value);
+    GlideString glideValue = GlideString.of(value);
+    when(mockReadConnPool.borrowObject()).thenReturn(mockClient);
+    when(mockClient.get(any(GlideString.class))).thenReturn(CompletableFuture.completedFuture(glideValue));
     byte[] result = spyConnection.readFromCache("myQueryKey");
-    assertEquals(value, result);
+    assertArrayEquals(value, result);
     verify(mockReadConnPool).borrowObject();
-    verify(mockConnection).sync();
-    verify(mockSyncCommands).get(any());
-    verify(mockReadConnPool).returnObject(mockConnection);
+    verify(mockClient).get(any(GlideString.class));
+    verify(mockReadConnPool).returnObject(mockClient);
   }
 
   @Test
@@ -408,14 +401,14 @@ public class CacheConnectionTest {
     when(spyConnection.getClusterHealthStateFromCacheMonitor()).thenReturn(CacheMonitor.HealthState.HEALTHY);
     doNothing().when(spyConnection).reportErrorToCacheMonitor(anyBoolean(), any(), any());
 
-    when(mockReadConnPool.borrowObject()).thenReturn(mockConnection);
-    when(mockConnection.sync()).thenReturn(mockSyncCommands);
-    when(mockSyncCommands.get(any())).thenThrow(new RuntimeException("test"));
+    when(mockReadConnPool.borrowObject()).thenReturn(mockClient);
+    when(mockClient.get(any(GlideString.class)))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("test")));
+
     assertNull(spyConnection.readFromCache("myQueryKey"));
     verify(mockReadConnPool).borrowObject();
-    verify(mockConnection).sync();
-    verify(mockSyncCommands).get(any());
-    verify(mockReadConnPool).invalidateObject(mockConnection);
+    verify(mockClient).get(any(GlideString.class));
+    verify(mockReadConnPool).invalidateObject(mockClient);
   }
 
   @ParameterizedTest
@@ -436,15 +429,15 @@ public class CacheConnectionTest {
     // Test WRITE operation
     if (isClusterMode) {
       // Mock cluster connection for write
-      when(mockWriteConnPool.borrowObject()).thenReturn(mockClusterConnection);
-      when(mockClusterConnection.async()).thenReturn(mockClusterAsyncCommands);
-      when(mockClusterAsyncCommands.set(any(), any(), any())).thenReturn(mockCacheResult);
+      when(mockWriteConnPool.borrowObject()).thenReturn(mockClusterClient);
+      when(mockClusterClient.set(any(GlideString.class), any(GlideString.class), any(SetOptions.class)))
+          .thenReturn(mockCacheResult);
       when(mockCacheResult.whenComplete(any(BiConsumer.class))).thenReturn(null);
     } else {
       // Mock standalone connection for write
-      when(mockWriteConnPool.borrowObject()).thenReturn(mockConnection);
-      when(mockConnection.async()).thenReturn(mockAsyncCommands);
-      when(mockAsyncCommands.set(any(), any(), any())).thenReturn(mockCacheResult);
+      when(mockWriteConnPool.borrowObject()).thenReturn(mockClient);
+      when(mockClient.set(any(GlideString.class), any(GlideString.class), any(SetOptions.class)))
+          .thenReturn(mockCacheResult);
       when(mockCacheResult.whenComplete(any(BiConsumer.class))).thenReturn(null);
     }
 
@@ -455,31 +448,27 @@ public class CacheConnectionTest {
     // Test READ operation
     if (isClusterMode) {
       // Mock cluster connection for read
-      when(mockReadConnPool.borrowObject()).thenReturn(mockClusterConnection);
-      when(mockClusterConnection.sync()).thenReturn(mockClusterSyncCommands);
-      when(mockClusterSyncCommands.get(any())).thenReturn(value);
+      GlideString glideValue = GlideString.of(value);
+      when(mockReadConnPool.borrowObject()).thenReturn(mockClusterClient);
+      when(mockClusterClient.get(any(GlideString.class))).thenReturn(CompletableFuture.completedFuture(glideValue));
     } else {
       // Mock standalone connection for read
-      when(mockReadConnPool.borrowObject()).thenReturn(mockConnection);
-      when(mockConnection.sync()).thenReturn(mockSyncCommands);
-      when(mockSyncCommands.get(any())).thenReturn(value);
+      GlideString glideValue = GlideString.of(value);
+      when(mockReadConnPool.borrowObject()).thenReturn(mockClient);
+      when(mockClient.get(any(GlideString.class))).thenReturn(CompletableFuture.completedFuture(glideValue));
     }
 
     byte[] result = spyConnection.readFromCache(key);
-    assertEquals(value, result);
+    assertArrayEquals(value, result);
     verify(mockReadConnPool).borrowObject();
 
     // Verify appropriate connection type was used
     if (isClusterMode) {
-      verify(mockClusterConnection).async();
-      verify(mockClusterConnection).sync();
-      verify(mockClusterAsyncCommands).set(any(), any(), any());
-      verify(mockClusterSyncCommands).get(any());
+      verify(mockClusterClient).set(any(GlideString.class), any(GlideString.class), any(SetOptions.class));
+      verify(mockClusterClient).get(any(GlideString.class));
     } else {
-      verify(mockConnection).async();
-      verify(mockConnection).sync();
-      verify(mockAsyncCommands).set(any(), any(), any());
-      verify(mockSyncCommands).get(any());
+      verify(mockClient).set(any(GlideString.class), any(GlideString.class), any(SetOptions.class));
+      verify(mockClient).get(any(GlideString.class));
     }
   }
 
@@ -499,33 +488,29 @@ public class CacheConnectionTest {
 
     // Test WRITE exception handling
     if (isClusterMode) {
-      when(mockWriteConnPool.borrowObject()).thenReturn(mockClusterConnection);
-      when(mockClusterConnection.async()).thenReturn(mockClusterAsyncCommands);
-      when(mockClusterAsyncCommands.set(any(), any(), any())).thenThrow(new RuntimeException("cluster write error"));
+      when(mockWriteConnPool.borrowObject()).thenReturn(mockClusterClient);
+      when(mockClusterClient.set(any(GlideString.class), any(GlideString.class), any(SetOptions.class))).thenThrow(new RuntimeException("cluster write error"));
     } else {
-      when(mockWriteConnPool.borrowObject()).thenReturn(mockConnection);
-      when(mockConnection.async()).thenReturn(mockAsyncCommands);
-      when(mockAsyncCommands.set(any(), any(), any())).thenThrow(new RuntimeException("standalone write error"));
+      when(mockWriteConnPool.borrowObject()).thenReturn(mockClient);
+      when(mockClient.set(any(GlideString.class), any(GlideString.class), any(SetOptions.class))).thenThrow(new RuntimeException("standalone write error"));
     }
 
     spyConnection.writeToCache(key, value, 100);
     verify(mockWriteConnPool).borrowObject();
-    verify(mockWriteConnPool).invalidateObject(isClusterMode ? mockClusterConnection : mockConnection);
+    verify(mockWriteConnPool).invalidateObject(isClusterMode ? mockClusterClient : mockClient);
 
     // Test READ exception handling
     if (isClusterMode) {
-      when(mockReadConnPool.borrowObject()).thenReturn(mockClusterConnection);
-      when(mockClusterConnection.sync()).thenReturn(mockClusterSyncCommands);
-      when(mockClusterSyncCommands.get(any())).thenThrow(new RuntimeException("cluster read error"));
+      when(mockReadConnPool.borrowObject()).thenReturn(mockClusterClient);
+      when(mockClusterClient.get(any(GlideString.class))).thenThrow(new RuntimeException("cluster read error"));
     } else {
-      when(mockReadConnPool.borrowObject()).thenReturn(mockConnection);
-      when(mockConnection.sync()).thenReturn(mockSyncCommands);
-      when(mockSyncCommands.get(any())).thenThrow(new RuntimeException("standalone read error"));
+      when(mockReadConnPool.borrowObject()).thenReturn(mockClient);
+      when(mockClient.get(any(GlideString.class))).thenThrow(new RuntimeException("standalone read error"));
     }
 
     assertNull(spyConnection.readFromCache(key));
     verify(mockReadConnPool).borrowObject();
-    verify(mockReadConnPool).invalidateObject(isClusterMode ? mockClusterConnection : mockConnection);
+    verify(mockReadConnPool).invalidateObject(isClusterMode ? mockClusterClient : mockClient);
   }
 
   @Test
@@ -544,8 +529,8 @@ public class CacheConnectionTest {
     connection.triggerPoolInit(true);
     connection.triggerPoolInit(false);
 
-    GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> readPool  = getInstancePool(connection,"readConnectionPool");
-    GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> writePool = getInstancePool(connection, "writeConnectionPool");
+    GenericObjectPool<BaseClient> readPool  = getInstancePool(connection,"readConnectionPool");
+    GenericObjectPool<BaseClient> writePool = getInstancePool(connection, "writeConnectionPool");
 
     assertNotNull(readPool, "read pool should be created");
     assertNotNull(writePool, "write pool should be created");
@@ -575,8 +560,8 @@ public class CacheConnectionTest {
     connection.triggerPoolInit(true);
     connection.triggerPoolInit(false);
 
-    GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> readPool  = getInstancePool(connection,"readConnectionPool");
-    GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> writePool = getInstancePool(connection, "writeConnectionPool");
+    GenericObjectPool<BaseClient> readPool  = getInstancePool(connection,"readConnectionPool");
+    GenericObjectPool<BaseClient> writePool = getInstancePool(connection, "writeConnectionPool");
 
     assertNotNull(readPool, "read pool should be created");
     assertNotNull(writePool, "write pool should be created");
@@ -609,10 +594,10 @@ public class CacheConnectionTest {
   }
 
   @SuppressWarnings("unchecked")
-  private static GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> getInstancePool(CacheConnection connection, String fieldName) throws Exception {
+  private static GenericObjectPool<BaseClient> getInstancePool(CacheConnection connection, String fieldName) throws Exception {
     Field f = CacheConnection.class.getDeclaredField(fieldName);
     f.setAccessible(true);
-    return (GenericObjectPool<StatefulRedisConnection<byte[], byte[]>>) f.get(connection);
+    return (GenericObjectPool<BaseClient>) f.get(connection);
   }
 
   private static void clearStaticRegistry() throws Exception {
@@ -642,19 +627,17 @@ public class CacheConnectionTest {
 
     // HEALTHY state: operations proceed
     when(spyConnection.getClusterHealthStateFromCacheMonitor()).thenReturn(CacheMonitor.HealthState.HEALTHY);
-    when(mockWriteConnPool.borrowObject()).thenReturn(mockConnection);
-    when(mockConnection.async()).thenReturn(mockAsyncCommands);
-    when(mockAsyncCommands.set(any(), any(), any())).thenReturn(mockCacheResult);
+    when(mockWriteConnPool.borrowObject()).thenReturn(mockClient);
+    when(mockClient.set(any(GlideString.class), any(GlideString.class), any(SetOptions.class))).thenReturn(mockCacheResult);
     when(mockCacheResult.whenComplete(any(BiConsumer.class))).thenReturn(null);
     spyConnection.writeToCache(key, value, 100);
     verify(mockWriteConnPool).borrowObject();
     verify(spyConnection).incrementInFlightSize(anyLong());
 
     // Error reporting on read failure
-    when(mockReadConnPool.borrowObject()).thenReturn(mockConnection);
-    when(mockConnection.sync()).thenReturn(mockSyncCommands);
+    when(mockReadConnPool.borrowObject()).thenReturn(mockClient);
     RuntimeException testException = new RuntimeException("Connection failed");
-    when(mockSyncCommands.get(any())).thenThrow(testException);
+    when(mockClient.get(any(GlideString.class))).thenThrow(testException);
     assertNull(spyConnection.readFromCache(key));
     verify(spyConnection).reportErrorToCacheMonitor(eq(false), eq(testException), eq("READ"));
 
@@ -694,10 +677,10 @@ public class CacheConnectionTest {
     connection2.triggerPoolInit(true);
     connection2.triggerPoolInit(false);
 
-    GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> readPool1 = getInstancePool(connection1, "readConnectionPool");
-    GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> readPool2 = getInstancePool(connection2, "readConnectionPool");
-    GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> writePool1 = getInstancePool(connection1, "writeConnectionPool");
-    GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> writePool2 = getInstancePool(connection2, "writeConnectionPool");
+    GenericObjectPool<BaseClient> readPool1 = getInstancePool(connection1, "readConnectionPool");
+    GenericObjectPool<BaseClient> readPool2 = getInstancePool(connection2, "readConnectionPool");
+    GenericObjectPool<BaseClient> writePool1 = getInstancePool(connection1, "writeConnectionPool");
+    GenericObjectPool<BaseClient> writePool2 = getInstancePool(connection2, "writeConnectionPool");
 
     assertSame(readPool1, readPool2, "Read pools should be the same instance");
     assertSame(writePool1, writePool2, "Write pools should be the same instance");
@@ -715,8 +698,8 @@ public class CacheConnectionTest {
     connection3.triggerPoolInit(true);
     connection3.triggerPoolInit(false);
 
-    GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> readPool3 = getInstancePool(connection3, "readConnectionPool");
-    GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> writePool3 = getInstancePool(connection3, "writeConnectionPool");
+    GenericObjectPool<BaseClient> readPool3 = getInstancePool(connection3, "readConnectionPool");
+    GenericObjectPool<BaseClient> writePool3 = getInstancePool(connection3, "writeConnectionPool");
 
     assertNotSame(readPool1, readPool3, "Read pools should be different instances");
     assertNotSame(writePool1, writePool3, "Write pools should be different instances");
@@ -732,8 +715,8 @@ public class CacheConnectionTest {
     connection4.triggerPoolInit(false);
     connection4.triggerPoolInit(true);
 
-    GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> writePool4 = getInstancePool(connection4, "writeConnectionPool");
-    GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> readPool4 = getInstancePool(connection4, "readConnectionPool");
+    GenericObjectPool<BaseClient> writePool4 = getInstancePool(connection4, "writeConnectionPool");
+    GenericObjectPool<BaseClient> readPool4 = getInstancePool(connection4, "readConnectionPool");
 
     assertSame(writePool1, writePool4, "Write pools should be shared for same RW endpoint");
     assertEquals(10, writePool4.getMaxTotal(), "Connection pool size should not be changed.");
@@ -769,9 +752,9 @@ public class CacheConnectionTest {
     t3.join();
 
     // All should reference the same pool
-    GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> pool1 = getInstancePool(connection1, "writeConnectionPool");
-    GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> pool2 = getInstancePool(connection2, "writeConnectionPool");
-    GenericObjectPool<StatefulRedisConnection<byte[], byte[]>> pool3 = getInstancePool(connection3, "writeConnectionPool");
+    GenericObjectPool<BaseClient> pool1 = getInstancePool(connection1, "writeConnectionPool");
+    GenericObjectPool<BaseClient> pool2 = getInstancePool(connection2, "writeConnectionPool");
+    GenericObjectPool<BaseClient> pool3 = getInstancePool(connection3, "writeConnectionPool");
 
     assertSame(pool1, pool2);
     assertSame(pool2, pool3);
@@ -843,9 +826,8 @@ public class CacheConnectionTest {
     byte[] testValue = "test_value".getBytes(StandardCharsets.UTF_8);
 
     // write operation with size calculation
-    when(mockWriteConnPool.borrowObject()).thenReturn(mockConnection);
-    when(mockConnection.async()).thenReturn(mockAsyncCommands);
-    when(mockAsyncCommands.set(any(byte[].class), any(byte[].class), any()))
+    when(mockWriteConnPool.borrowObject()).thenReturn(mockClient);
+    when(mockClient.set(any(GlideString.class), any(GlideString.class), any(SetOptions.class)))
         .thenReturn(mockCacheResult);
     when(mockCacheResult.whenComplete(any(BiConsumer.class))).thenAnswer(invocation -> {
       BiConsumer<String, Throwable> callback = invocation.getArgument(0);
@@ -857,40 +839,41 @@ public class CacheConnectionTest {
     Thread.sleep(100); // Wait for async completion
 
     // set was called with prefixed key
-    verify(mockAsyncCommands).set(
-        argThat(key -> {
-          if (key.length < 4) return false;
-          String keyStr = new String(key, 0, 4, StandardCharsets.UTF_8);
+    verify(mockClient).set(
+        argThat((GlideString key) -> {
+          byte[] keyBytes = key.getBytes();
+          if (keyBytes.length < 4) return false;
+          String keyStr = new String(keyBytes, 0, 4, StandardCharsets.UTF_8);
           return keyStr.equals(prefix);
         }),
-        eq(testValue),
-        any()
+        argThat((GlideString value) -> Arrays.equals(value.getBytes(), testValue)),
+        any(SetOptions.class)
     );
 
     // write size calculation includes prefix (prefix=4 + hash=48 + value=10 = 62)
     long expectedSize = prefix.length() + 48 + testValue.length;
     verify(spyConnection).incrementInFlightSize(expectedSize);
     verify(spyConnection).decrementInFlightSize(expectedSize);
-    verify(mockWriteConnPool).returnObject(mockConnection);
+    verify(mockWriteConnPool).returnObject(mockClient);
 
     // read operation
     byte[] expectedValue = "cached_data".getBytes(StandardCharsets.UTF_8);
-    when(mockReadConnPool.borrowObject()).thenReturn(mockConnection);
-    when(mockConnection.sync()).thenReturn(mockSyncCommands);
-    when(mockSyncCommands.get(any(byte[].class))).thenReturn(expectedValue);
+    when(mockReadConnPool.borrowObject()).thenReturn(mockClient);
+    when(mockClient.get(any(GlideString.class))).thenReturn(CompletableFuture.completedFuture(GlideString.of(expectedValue)));
 
     byte[] result = spyConnection.readFromCache(testKey);
 
     assertArrayEquals(expectedValue, result);
 
     // get was called with prefixed key
-    verify(mockSyncCommands).get(argThat(key -> {
-      if (key.length < 4) return false;
-      String keyStr = new String(key, 0, 4, StandardCharsets.UTF_8);
+    verify(mockClient).get(argThat((GlideString key) -> {
+      byte[] keyBytes = key.getBytes();
+      if (keyBytes.length < 4) return false;
+      String keyStr = new String(keyBytes, 0, 4, StandardCharsets.UTF_8);
       return keyStr.equals(prefix);
     }));
 
-    verify(mockReadConnPool).returnObject(mockConnection);
+    verify(mockReadConnPool).returnObject(mockClient);
   }
 
   private Properties createBaseProperties() {

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CacheMonitorTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CacheMonitorTest.java
@@ -20,8 +20,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-import io.lettuce.core.RedisCommandExecutionException;
-import io.lettuce.core.RedisConnectionException;
+import glide.api.models.exceptions.ConnectionException;
+import glide.api.models.exceptions.GlideException;
+import glide.api.models.exceptions.RequestException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.time.Duration;
@@ -216,7 +217,7 @@ public class CacheMonitorTest {
 
     // Test 1: Recoverable error transitions to SUSPECT
     CacheMonitor.reportError("localhost:6379", "localhost:6380", true,
-        new RedisConnectionException("Connection refused"), "SET");
+        new ConnectionException("Connection refused"), "SET");
     assertEquals(CacheMonitor.HealthState.SUSPECT, cluster.rwHealthState);
     assertEquals(CacheMonitor.HealthState.HEALTHY, cluster.roHealthState);
     verify(mockErrorCounter, times(1)).inc();
@@ -231,7 +232,7 @@ public class CacheMonitorTest {
 
     // Test 3: RO endpoint error transitions independently
     CacheMonitor.reportError("localhost:6379", "localhost:6380", false,
-        new RedisCommandExecutionException("READONLY"), "SET");
+        new RequestException("READONLY"), "SET");
     assertEquals(CacheMonitor.HealthState.SUSPECT, cluster.rwHealthState);
     assertEquals(CacheMonitor.HealthState.SUSPECT, cluster.roHealthState);
     verify(mockErrorCounter, times(3)).inc();
@@ -239,7 +240,7 @@ public class CacheMonitorTest {
 
     // Test 4: Unregistered cluster logs warning without metrics
     CacheMonitor.reportError("localhost:9999", null, true,
-        new RedisConnectionException("Connection refused"), "SET");
+        new ConnectionException("Connection refused"), "SET");
     verify(mockErrorCounter, times(3)).inc();
     verify(mockStateTransitionCounter, times(2)).inc();
   }
@@ -318,7 +319,7 @@ public class CacheMonitorTest {
     CacheMonitor instance = (CacheMonitor) getStaticField("instance");
 
     // Success: maintains healthy state
-    when(mockRwPingConnection.isOpen()).thenReturn(true);
+    when(mockRwPingConnection.isConnected()).thenReturn(true);
     when(mockRwPingConnection.ping()).thenReturn(true);
     invokeExecutePing(instance, cluster, true);
     assertEquals(CacheMonitor.HealthState.HEALTHY, cluster.rwHealthState);
@@ -356,9 +357,9 @@ public class CacheMonitorTest {
     CacheMonitor.ClusterHealthState cluster = getCluster("localhost:6379", "localhost:6380");
     CacheMonitor instance = (CacheMonitor) getStaticField("instance");
 
-    when(mockRwPingConnection.isOpen()).thenReturn(true);
+    when(mockRwPingConnection.isConnected()).thenReturn(true);
     when(mockRwPingConnection.ping()).thenReturn(false);
-    when(mockRoPingConnection.isOpen()).thenReturn(true);
+    when(mockRoPingConnection.isConnected()).thenReturn(true);
     when(mockRoPingConnection.ping()).thenReturn(true);
 
     invokeExecutePing(instance, cluster, true);
@@ -368,12 +369,14 @@ public class CacheMonitorTest {
 
     // Connection closed = failure (no ping call)
     reset(mockRwPingConnection);
-    when(mockRwPingConnection.isOpen()).thenReturn(false);
+    when(mockRwPingConnection.isConnected()).thenReturn(false);
+    cluster.rwPingConnection = null;
     invokeExecutePing(instance, cluster, true);
     verify(mockRwPingConnection, never()).ping();
 
     // Exception during ping = failure
-    when(mockRwPingConnection.isOpen()).thenReturn(true);
+    when(mockRwPingConnection.isConnected()).thenReturn(true);
+    cluster.rwPingConnection = mockRwPingConnection;
     when(mockRwPingConnection.ping()).thenThrow(new RuntimeException("timeout"));
     invokeExecutePing(instance, cluster, true);
     assertEquals(CacheMonitor.HealthState.SUSPECT, cluster.rwHealthState);
@@ -388,7 +391,7 @@ public class CacheMonitorTest {
     cluster.inFlightWriteSizeBytes.set(500);
 
     reset(mockRwPingConnection);
-    when(mockRwPingConnection.isOpen()).thenReturn(true);
+    when(mockRwPingConnection.isConnected()).thenReturn(true);
     when(mockRwPingConnection.ping()).thenReturn(true);
     invokeExecutePing(instance, cluster, true);
     invokeExecutePing(instance, cluster, true);
@@ -404,7 +407,7 @@ public class CacheMonitorTest {
 
   @Test
   void testRun_MonitoringBehavior() throws Exception {
-    when(mockRwPingConnection.isOpen()).thenReturn(true);
+    when(mockRwPingConnection.isConnected()).thenReturn(true);
     when(mockRwPingConnection.ping()).thenReturn(true);
 
     // HEALTHY: skips ping by default
@@ -459,9 +462,9 @@ public class CacheMonitorTest {
     cluster.transitionToState(CacheMonitor.HealthState.SUSPECT, true, "test_setup", null);
     instance = (CacheMonitor) getStaticField("instance");
     reset(mockRwPingConnection, mockRoPingConnection);
-    when(mockRwPingConnection.isOpen()).thenReturn(true);
+    when(mockRwPingConnection.isConnected()).thenReturn(true);
     when(mockRwPingConnection.ping()).thenReturn(true);
-    when(mockRoPingConnection.isOpen()).thenReturn(true);
+    when(mockRoPingConnection.isConnected()).thenReturn(true);
     when(mockRoPingConnection.ping()).thenReturn(true);
     spy = spy(instance);
     sleepCount.set(0);
@@ -481,7 +484,7 @@ public class CacheMonitorTest {
     cluster.transitionToState(CacheMonitor.HealthState.SUSPECT, true, "test_setup", null);
     instance = (CacheMonitor) getStaticField("instance");
     reset(mockRwPingConnection);
-    when(mockRwPingConnection.isOpen()).thenReturn(true);
+    when(mockRwPingConnection.isConnected()).thenReturn(true);
     when(mockRwPingConnection.ping())
         .thenThrow(new RuntimeException("Test exception"))
         .thenReturn(true);
@@ -503,19 +506,19 @@ public class CacheMonitorTest {
     classifyMethod.setAccessible(true);
 
     assertEquals(CacheMonitor.ErrorCategory.CONNECTION,
-        classifyMethod.invoke(null, new RedisConnectionException("Connection refused")));
+        classifyMethod.invoke(null, new ConnectionException("Connection refused")));
     assertEquals(CacheMonitor.ErrorCategory.COMMAND,
-        classifyMethod.invoke(null, new RedisCommandExecutionException("READONLY")));
+        classifyMethod.invoke(null, new RequestException("READONLY")));
     assertEquals(CacheMonitor.ErrorCategory.COMMAND,
-        classifyMethod.invoke(null, new RedisCommandExecutionException("WRONGTYPE")));
+        classifyMethod.invoke(null, new RequestException("WRONGTYPE")));
     assertEquals(CacheMonitor.ErrorCategory.RESOURCE,
-        classifyMethod.invoke(null, new RedisCommandExecutionException("OOM")));
+        classifyMethod.invoke(null, new RequestException("OOM")));
     assertEquals(CacheMonitor.ErrorCategory.RESOURCE,
-        classifyMethod.invoke(null, new RedisCommandExecutionException("CLUSTERDOWN")));
+        classifyMethod.invoke(null, new RequestException("CLUSTERDOWN")));
     assertEquals(CacheMonitor.ErrorCategory.RESOURCE,
-        classifyMethod.invoke(null, new RedisCommandExecutionException((String) null)));
+        classifyMethod.invoke(null, new RequestException((String) null)));
     assertEquals(CacheMonitor.ErrorCategory.CONNECTION,
-        classifyMethod.invoke(null, new io.lettuce.core.RedisException("Generic error")));
+        classifyMethod.invoke(null, new GlideException("Generic error")));
     assertEquals(CacheMonitor.ErrorCategory.DATA,
         classifyMethod.invoke(null, new RuntimeException("Serialization failed")));
 
@@ -540,10 +543,10 @@ public class CacheMonitorTest {
     assertFalse((Boolean) pingMethod.invoke(instance, cluster, true));
 
     cluster.rwPingConnection = mockRwPingConnection;
-    when(mockRwPingConnection.isOpen()).thenReturn(false);
+    when(mockRwPingConnection.isConnected()).thenReturn(false);
     assertFalse((Boolean) pingMethod.invoke(instance, cluster, true));
 
-    when(mockRwPingConnection.isOpen()).thenReturn(true);
+    when(mockRwPingConnection.isConnected()).thenReturn(true);
     when(mockRwPingConnection.ping()).thenReturn(true);
     assertTrue((Boolean) pingMethod.invoke(instance, cluster, true));
 


### PR DESCRIPTION
### Summary

<!--- General summary / title -->
This PR aims in implementing the Valkey Glide client for establishing cache connection. 

### Description

<!--- Details of what you changed -->
Along with the current Lettuce client implementation, this PR contains the Valkey Glide Client pool implementation to establish cache connection, includes writes and reads from the cache using latest Valkey Glide 2.2.0 GA version. 

Includes a `cacheClientType` property to switch between Valkey Glide and Lettuce clients. 

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.