### PR TITLE
Add multi-shard ElastiCache cluster support for JDBC caching

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CacheMonitor.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CacheMonitor.java
@@ -520,7 +520,7 @@ public class CacheMonitor implements Runnable {
     try {
       return conn.ping();
     } catch (Exception e) {
-      LOGGER.warning("[ping()] Ping failed for " + (isRw ? cluster.rwEndpoint : cluster.roEndpoint) + " (" + (isRw ? "RW" : "RO") + "): " + e.getMessage());
+      LOGGER.warning("Ping failed for " + (isRw ? cluster.rwEndpoint : cluster.roEndpoint) + " (" + (isRw ? "RW" : "RO") + "): " + e.getMessage());
       return false;
     }
   }


### PR DESCRIPTION
### Summary
Add multi-shard ElastiCache cluster support for JDBC caching driver

### Description
The JDBC caching driver now supports multi-shard ElastiCache clusters (CME) in addition to single-shard clusters (CMD).

**Changes:**
- Automatic cluster topology detection via `INFO cluster` command during initialization
- Uses `RedisClusterClient` for multi-shard clusters (cluster_enabled:1)
- Uses `RedisClient` for single-shard clusters (cluster_enabled:0)
- Connection pools support both `StatefulRedisConnection` and `StatefulRedisClusterConnection` via `StatefulConnection` base type
- Updated `CacheMonitor` to create appropriate ping connections based on cluster mode

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
