### PR TITLE
Caching: Multicache endpoint implementation

### DIFF
--- a/examples/AWSDriverExample/src/main/java/software/amazon/DatabaseConnectionWithCacheExample.java
+++ b/examples/AWSDriverExample/src/main/java/software/amazon/DatabaseConnectionWithCacheExample.java
@@ -31,6 +31,14 @@ public class DatabaseConnectionWithCacheExample {
   private static final String CACHE_IN_FLIGHT_WRITE_SIZE_LIMIT = env.get("CACHE_IN_FLIGHT_WRITE_SIZE_LIMIT");
   private static final String CACHE_HEALTH_CHECK_IN_HEALTHY_STATE = env.get("CACHE_HEALTH_CHECK_IN_HEALTHY_STATE");
 
+  // If multi endpoint is configured
+  private static final String CACHE_RW_SERVER_ADDR2 = env.get("CACHE_RW_SERVER_ADDR2");
+  private static final String CACHE_RO_SERVER_ADDR2 = env.get("CACHE_RO_SERVER_ADDR2");
+  private static final String CACHE_NAME2 = env.get("CACHE_NAME2");
+  // Both IAM and traditional auth uses the same CACHE_USERNAME
+  private static final String CACHE_USERNAME2 = env.get("CACHE_USERNAME2"); // e.g., "iam-user-01" / "username"
+  private static final String CACHE_IAM_REGION2 = env.get("CACHE_IAM_REGION2");
+
   public static void main(String[] args) throws SQLException {
     final Properties properties = new Properties();
     final Logger LOGGER = Logger.getLogger(DatabaseConnectionWithCacheExample.class.getName());
@@ -76,6 +84,92 @@ public class DatabaseConnectionWithCacheExample {
           }
         } catch (Exception e) {
           LOGGER.warning("Error: " + e.getMessage());
+        }
+      });
+      threads[t].start();
+    }
+    // Wait for all threads to complete
+    for (Thread thread : threads) {
+      try {
+        thread.join();
+      } catch (InterruptedException e) {
+        LOGGER.warning("Thread interrupted: " + e.getMessage());
+      }
+    }
+
+    // multi cache endpoint example.
+    runMultiEndPointExample();
+  }
+
+  /*
+  * Multi cache Endpoint Example
+  * This example demonstrates how to use multiple cache endpoints.
+  * It creates two threads, each using a different cache endpoint.
+  * The cache endpoints are configured in the properties object.
+  * */
+  public static void runMultiEndPointExample() throws SQLException {
+    final Logger LOGGER = Logger.getLogger(DatabaseConnectionWithCacheExample.class.getName());
+    String queryStr = "/*+ CACHE_PARAM(ttl=300s) */ select * from cinemas";
+
+    Properties properties1 = new Properties();
+    properties1.setProperty("user", USERNAME);
+    properties1.setProperty("password", PASSWORD);
+    properties1.setProperty("wrapperPlugins", "dataRemoteCache");
+    properties1.setProperty("cacheEndpointAddrRw", CACHE_RW_SERVER_ADDR);
+    properties1.setProperty("cacheEndpointAddrRo", CACHE_RO_SERVER_ADDR);
+    properties1.setProperty("cacheUseSSL", CACHE_USE_SSL);
+    properties1.setProperty("wrapperLogUnclosedConnections", "true");
+    properties1.setProperty("cacheConnectionTimeout", CACHE_CONNECTION_TIMEOUT);
+    properties1.setProperty("cacheConnectionPoolSize", CACHE_CONNECTION_POOL_SIZE);
+    // If the cache server is authenticated with IAM
+    properties1.setProperty("cacheName", CACHE_NAME);
+    properties1.setProperty("cacheUsername", CACHE_USERNAME);
+    properties1.setProperty("cacheIamRegion", CACHE_IAM_REGION);
+    // If the cache server is authenticated with traditional username password
+    // properties.setProperty("cachePassword", CACHE_PASSWORD);
+    properties1.setProperty("failWhenCacheDown", FAIL_WHEN_CACHE_DOWN);
+    properties1.setProperty("cacheInFlightWriteSizeLimitBytes", CACHE_IN_FLIGHT_WRITE_SIZE_LIMIT);
+    properties1.setProperty("cacheHealthCheckInHealthyState", CACHE_HEALTH_CHECK_IN_HEALTHY_STATE);
+
+
+    Properties properties2 = new Properties();
+    properties2.setProperty("user", USERNAME);
+    properties2.setProperty("password", PASSWORD);
+    properties2.setProperty("wrapperPlugins", "dataRemoteCache");
+    properties2.setProperty("cacheEndpointAddrRw", CACHE_RW_SERVER_ADDR2);
+    properties2.setProperty("cacheEndpointAddrRo", CACHE_RO_SERVER_ADDR2);
+    properties2.setProperty("cacheUseSSL", CACHE_USE_SSL);
+    properties2.setProperty("wrapperLogUnclosedConnections", "true");
+    properties2.setProperty("cacheConnectionTimeout", CACHE_CONNECTION_TIMEOUT);
+    properties2.setProperty("cacheConnectionPoolSize", CACHE_CONNECTION_POOL_SIZE);
+    // If the cache server is authenticated with IAM
+    properties2.setProperty("cacheName", CACHE_NAME2);
+    properties2.setProperty("cacheUsername", CACHE_USERNAME2);
+    properties2.setProperty("cacheIamRegion", CACHE_IAM_REGION2);
+    // If the cache server is authenticated with traditional username password
+    // properties.setProperty("cachePassword", CACHE_PASSWORD2);
+    properties2.setProperty("failWhenCacheDown", FAIL_WHEN_CACHE_DOWN);
+    properties2.setProperty("cacheInFlightWriteSizeLimitBytes", CACHE_IN_FLIGHT_WRITE_SIZE_LIMIT);
+    properties2.setProperty("cacheHealthCheckInHealthyState", CACHE_HEALTH_CHECK_IN_HEALTHY_STATE);
+
+    // Create threads with different cache endpoints
+    Thread[] threads = new Thread[THREAD_COUNT];
+
+    for (int t = 0; t < THREAD_COUNT; t++) {
+      final Properties threadProps = (t%2 == 0) ? properties1 : properties2;
+      final int threadNum = t + 1;
+
+      threads[t] = new Thread(() -> {
+        try (Connection conn = DriverManager.getConnection(DB_CONNECTION_STRING, threadProps)) {
+          long endTime = System.currentTimeMillis() + TEST_DURATION_MS;
+          try (Statement stmt = conn.createStatement()) {
+            while (System.currentTimeMillis() < endTime) {
+              ResultSet rs = stmt.executeQuery(queryStr);
+              System.out.println("Thread " + threadNum + " executed SQL query with result sets: " + rs.toString());
+            }
+          }
+        } catch (Exception e) {
+          LOGGER.warning("Thread " + threadNum + " error: " + e.getMessage());
         }
       });
       threads[t].start();


### PR DESCRIPTION
### Summary
<!--- General summary / title -->
Add multi-endpoint cache connection pool support

### Description

<!--- Details of what you changed -->
Enables the driver to support multiple cache cluster endpoints with independent connection pools, allowing different database connections to use different cache clusters.

Refactored CacheConnection to support multiple cache endpoints by implementing a per-endpoint connection pool registry:

#### Key Changes
1. Per-Endpoint Pool Registry: 

- Added `static ConcurrentHashMap<String, GenericObjectPool>` registry to store pools per unique endpoint
- Pool keys use format `"RW:<endpoint>" or "RO:<endpoint>"` to prevent collisions when same endpoint is used for both read and write
- Pools are shared across `CacheConnection` instances with identical endpoints

2. Pool Lifecycle Management: 

- Changed from static pools to instance-level volatile fields that reference shared pools from registry
- Implemented thread-safe pool creation using double-checked locking with separate READ_LOCK and WRITE_LOCK
- Pool size can only increase (never decrease) when reused by connections with larger pool size requirements

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.