### PR TITLE
Enforce maximum TTL to prevent indefinite caching and log security warning when used with no-auth

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CacheConnection.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CacheConnection.java
@@ -270,6 +270,10 @@ public class CacheConnection {
       throw new IllegalArgumentException(
           "Cannot specify both IAM authentication (cacheIamRegion) and traditional authentication (cachePassword). Choose one authentication method.");
     }
+    // Warn if no authentication is configured
+    if (!this.iamAuthEnabled && !hasTraditionalAuth) {
+      LOGGER.warning("Cache connection configured without authentication. For better security, please use user/password based auth or IAM auth.");
+    }
     if (this.cacheRwServerAddr == null) {
       throw new IllegalArgumentException("Cache endpoint address is required");
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/DataRemoteCachePlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/DataRemoteCachePlugin.java
@@ -47,6 +47,7 @@ public class DataRemoteCachePlugin extends AbstractConnectionPlugin {
   private static final String QUERY_HINT_START_PATTERN = "/*";
   private static final String QUERY_HINT_END_PATTERN = "*/";
   private static final String CACHE_PARAM_PATTERN = "CACHE_PARAM(";
+  private static final int MAX_TTL_SECONDS = 15552000; // 180 days (half a year)
   private static final String TELEMETRY_CACHE_LOOKUP = "jdbc-cache-lookup";
   private static final String TELEMETRY_DATABASE_QUERY = "jdbc-database-query";
   private static final Set<String> subscribedMethods = Collections.unmodifiableSet(new HashSet<>(
@@ -232,6 +233,12 @@ public class DataRemoteCachePlugin extends AbstractConnectionPlugin {
             // treat negative and 0 ttls as not cacheable
             if (ttlValue <= 0) {
               return null;
+            }
+            // Maximum TTL allowed is 180 days
+            if (ttlValue > MAX_TTL_SECONDS) {
+              LOGGER.warning(String.format("TTL value %d exceeds maximum allowed %d seconds. Using maximum TTL.",
+                  ttlValue, MAX_TTL_SECONDS));
+              ttlValue = MAX_TTL_SECONDS;
             }
           } catch (NumberFormatException e) {
             LOGGER.warning(String.format("Invalid TTL format of %s for query %s", value, queryHint));

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/DataRemoteCachePluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/DataRemoteCachePluginTest.java
@@ -100,6 +100,9 @@ public class DataRemoteCachePluginTest {
     assertEquals(180, plugin.getTtlForQuery("FIRST_ROWS(10) CACHE_PARAM(ttl=180s) PARALLEL(4)"));
     assertEquals(200, plugin.getTtlForQuery("foo=bar,CACHE_PARAM(ttl=200s),baz=qux"));
 
+    // Maximum TTL enforcement
+    assertEquals(15552000, plugin.getTtlForQuery("CACHE_PARAM(ttl=1000000000s)"));
+
     // Whitespace handling
     assertEquals(400, plugin.getTtlForQuery("CACHE_PARAM( ttl=400s )"));
     assertEquals(500, plugin.getTtlForQuery("CACHE_PARAM(ttl = 500s)"));


### PR DESCRIPTION
### Summary

- Enforce maximum TTL to prevent indefinite caching. Currently set to be 180 days.
- Add security warning for cache connections without authentication

### Description

Added check in `DataRemoteCachePlugin` for TTL.
Added check in `CacheConnection` for no-auth.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.