### PR TITLE
minor fix: disable VALKEY_CACHE for HibernateTests

### DIFF
--- a/wrapper/src/test/java/integration/container/tests/hibernate/HibernateTests.java
+++ b/wrapper/src/test/java/integration/container/tests/hibernate/HibernateTests.java
@@ -58,7 +58,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
     TestEnvironmentFeatures.RUN_HIBERNATE_TESTS_ONLY,
     TestEnvironmentFeatures.RUN_AUTOSCALING_TESTS_ONLY,
     TestEnvironmentFeatures.BLUE_GREEN_DEPLOYMENT,
-    TestEnvironmentFeatures.RUN_DB_METRICS_ONLY})
+    TestEnvironmentFeatures.RUN_DB_METRICS_ONLY,
+    TestEnvironmentFeatures.VALKEY_CACHE})
 @MakeSureFirstInstanceWriter
 @Order(21)
 public class HibernateTests {


### PR DESCRIPTION
Disabled VALKEY_CACHE for HibernateTests to avoid table conflict with HibernateCachingTests

### Summary

When `VALKEY_CACHE` feature is enabled in the test environment, both HibernateCachingTests and HibernateTestseiifcbn run simultaneously and all try to create the same database tables (skill), causing "Table already exists" conflicts. We need to add `VALKEY_CACHE` to the @DisableOnTestFeature for HibernateTests to fix it.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.