### PR TITLE
fix: telemetry level and proper connection closing

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CacheConnection.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CacheConnection.java
@@ -76,6 +76,9 @@ public class CacheConnection {
   private static final int DEFAULT_MAX_POOL_SIZE = 200;
   private static final long DEFAULT_MAX_BORROW_WAIT_MS = 100;
   private static final long TOKEN_CACHE_DURATION = 15 * 60 - 30;
+  private static volatile ClientResources sharedClientResources;
+  private static final ResourceLock clientResourcesLock = new ResourceLock();
+
   private final FullServicesContainer servicesContainer;
 
   private static final ResourceLock connectionInitializationLock = new ResourceLock();
@@ -401,6 +404,24 @@ public class CacheConnection {
     return poolConfig;
   }
 
+  private static ClientResources getSharedClientResources() {
+    if (sharedClientResources == null) {
+      try (ResourceLock ignored = clientResourcesLock.obtain()) {
+        if (sharedClientResources == null) {
+          sharedClientResources = ClientResources.builder()
+              .dnsResolver(new DirContextDnsResolver())
+              .reconnectDelay(
+                  Delay.fullJitter(
+                      Duration.ofMillis(100),
+                      Duration.ofSeconds(10),
+                      100, TimeUnit.MILLISECONDS))
+              .build();
+        }
+      }
+    }
+    return sharedClientResources;
+  }
+
   /**
    * Creates a Redis connection for either standalone or cluster mode.
    * Returns StatefulConnection which works for both RedisClient and RedisClusterClient.
@@ -408,14 +429,7 @@ public class CacheConnection {
   private static StatefulConnection<byte[], byte[]> createRedisConnection(
       boolean isReadOnly, RedisURI redisUri, boolean isClusterMode) {
 
-    ClientResources resources = ClientResources.builder()
-        .dnsResolver(new DirContextDnsResolver())
-        .reconnectDelay(
-            Delay.fullJitter(
-                Duration.ofMillis(100),      // minimum 100ms delay
-                Duration.ofSeconds(10),       // maximum 10s delay
-                100, TimeUnit.MILLISECONDS))  // 100ms base
-        .build();
+    ClientResources resources = getSharedClientResources();
 
     StatefulConnection<byte[], byte[]> conn;
 
@@ -832,6 +846,10 @@ public class CacheConnection {
 
   // Used for integration testing only to avoid cross tests pollution
   public static void clearEndpointPoolRegistry() {
+    CacheMonitor.resetInstance();
+    for (GenericObjectPool<StatefulConnection<byte[], byte[]>> pool : endpointToPoolRegistry.values()) {
+      pool.close();
+    }
     endpointToPoolRegistry.clear();
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CacheMonitor.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CacheMonitor.java
@@ -525,4 +525,15 @@ public class CacheMonitor extends AbstractMonitor {
       return false;
     }
   }
+
+  // Used for integration testing only to reset singleton state between tests
+  public static void resetInstance() {
+    synchronized (INSTANCE_LOCK) {
+      if (instance != null) {
+        instance.stop.set(true);
+        instance = null;
+      }
+      clusterStates.clear();
+    }
+  }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/DataRemoteCachePlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/DataRemoteCachePlugin.java
@@ -350,7 +350,7 @@ public class DataRemoteCachePlugin extends AbstractConnectionPlugin implements S
     // not executed in a transaction as a transaction typically need to return consistent results.
     if (!isInTransaction && (configuredQueryTtl != null)) {
       cacheContext = telemetryFactory.openTelemetryContext(
-          TELEMETRY_CACHE_LOOKUP, TelemetryTraceLevel.TOP_LEVEL);
+          TELEMETRY_CACHE_LOOKUP, TelemetryTraceLevel.NESTED);
       Exception cacheException = null;
       try {
         result = fetchResultSetFromCache(mainQuery);

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/DataRemoteCachePluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/DataRemoteCachePluginTest.java
@@ -371,7 +371,7 @@ public class DataRemoteCachePluginTest {
     // Verify TelemetryContext behavior for cache miss and hit scenario
     // First call: Cache miss + Database call
     verify(mockTelemetryFactory, times(2)).openTelemetryContext(eq("jdbc-cache-lookup"),
-        eq(TelemetryTraceLevel.TOP_LEVEL));
+        eq(TelemetryTraceLevel.NESTED));
     verify(mockTelemetryFactory, times(1)).openTelemetryContext(eq("jdbc-database-query"),
         eq(TelemetryTraceLevel.NESTED));
     // Cache context calls: 1 miss (setSuccess(false)) + 1 hit (setSuccess(true))
@@ -441,7 +441,7 @@ public class DataRemoteCachePluginTest {
     // Verify TelemetryContext behavior for cache miss and hit scenario
     // First call: Cache miss + Database call
     verify(mockTelemetryFactory, times(2)).openTelemetryContext(eq("jdbc-cache-lookup"),
-        eq(TelemetryTraceLevel.TOP_LEVEL));
+        eq(TelemetryTraceLevel.NESTED));
     verify(mockTelemetryFactory, times(1)).openTelemetryContext(eq("jdbc-database-query"),
         eq(TelemetryTraceLevel.NESTED));
     // Cache context calls: 1 miss (setSuccess(false)) + 1 hit (setSuccess(true))
@@ -709,7 +709,7 @@ public class DataRemoteCachePluginTest {
     verify(mockCacheBypassCounter, never()).inc();
     // Verify TelemetryContext behavior for cache miss and hit scenario
     verify(mockTelemetryFactory, times(11)).openTelemetryContext(eq("jdbc-cache-lookup"),
-        eq(TelemetryTraceLevel.TOP_LEVEL));
+        eq(TelemetryTraceLevel.NESTED));
     verify(mockTelemetryFactory, times(1)).openTelemetryContext(eq("jdbc-database-query"),
         eq(TelemetryTraceLevel.NESTED));
     verify(mockTelemetryContext, times(1)).setSuccess(false); // Cache miss


### PR DESCRIPTION
### Summary

Fix Lettuce resource leak causing integration test failures across test runs

### Description

- The CacheMonitor static singleton was never reset between tests. After the first test's cleanup terminated its executor, subsequent tests reused the stale instance and failed when attempting to submit tasks to the dead ThreadPoolExecutor.
- `clearEndpointPoolRegistry()` cleared the pool map without closing the pools, leaving Lettuce `ClientResources` (Netty event loops, `HashedWheelTimer`) orphaned and improperly shut down.

Changes:

- Added `CacheMonitor.resetInstance()` to clear the singleton and static cluster state between tests.
- Updated `CacheConnection.clearEndpointPoolRegistry()` to call `CacheMonitor.resetInstance()` and close all connection pools before clearing the registry.
- Optimized the code such that `ClientResources` is now shared across the pool rather than for each connection.  

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.